### PR TITLE
MetadataReference and in memory assemblies support

### DIFF
--- a/src/ConfigR/ScriptConfig.cs
+++ b/src/ConfigR/ScriptConfig.cs
@@ -2,6 +2,8 @@
 //  Copyright (c) ConfigR contributors. (configr.net@gmail.com)
 // </copyright>
 
+using Microsoft.CodeAnalysis;
+
 namespace ConfigR
 {
     using System.Diagnostics.CodeAnalysis;
@@ -12,10 +14,19 @@ namespace ConfigR
     public abstract class ScriptConfig : BasicConfig
     {
         private readonly Assembly[] references;
+        private MetadataReference[] metadataReferences;
 
         protected ScriptConfig(params Assembly[] references)
         {
             this.references = (references ?? Enumerable.Empty<Assembly>()).ToArray();
+        }
+
+#pragma warning disable CS3001
+        protected ScriptConfig(Assembly[] references, MetadataReference[] metadataReferences)
+#pragma warning restore CS3001
+        {
+            this.references = (references ?? Enumerable.Empty<Assembly>()).ToArray();
+            this.metadataReferences = (metadataReferences ?? Enumerable.Empty<MetadataReference>()).ToArray();
         }
 
         public override ISimpleConfig Load()
@@ -26,7 +37,7 @@ namespace ConfigR
 
         protected virtual void Load(string scriptPath)
         {
-            new ScriptConfigLoader(this.references.ToArray()).LoadFromFile(this, scriptPath);
+            new ScriptConfigLoader(this.references, this.metadataReferences).LoadFromFile(this, scriptPath);
         }
 
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Not appropriate.")]

--- a/src/ConfigR/ScriptFileConfig.cs
+++ b/src/ConfigR/ScriptFileConfig.cs
@@ -2,6 +2,8 @@
 //  Copyright (c) ConfigR contributors. (configr.net@gmail.com)
 // </copyright>
 
+using Microsoft.CodeAnalysis;
+
 namespace ConfigR
 {
     using System.Reflection;
@@ -12,6 +14,14 @@ namespace ConfigR
 
         public ScriptFileConfig(string path, params Assembly[] references)
             : base(references)
+        {
+            this.path = path;
+        }
+
+#pragma warning disable CS3001
+        public ScriptFileConfig(string path, Assembly[] references, MetadataReference[] metadataReferences)
+#pragma warning restore CS3001
+            : base(references, metadataReferences)
         {
             this.path = path;
         }

--- a/src/ConfigR/Scripting/ScriptConfigLoader.cs
+++ b/src/ConfigR/Scripting/ScriptConfigLoader.cs
@@ -49,9 +49,9 @@ namespace ConfigR.Scripting
             };
 
             var options = ScriptOptions.Default
-                                .AddReferences(this.metadataReferences)
-                //.WithMetadataResolver(ScriptMetadataResolver.Default.WithSearchPaths(searchPaths))
-                //.WithSourceResolver(ScriptSourceResolver.Default.WithSearchPaths(searchPaths))
+                .AddReferences(this.metadataReferences)
+                .WithMetadataResolver(ScriptMetadataResolver.Default.WithSearchPaths(searchPaths))
+                .WithSourceResolver(ScriptSourceResolver.Default.WithSearchPaths(searchPaths))
                 .AddReferences(typeof(Config).Assembly)
                 .AddReferences(this.references)
                 .AddImports("System", "System.Collections.Generic", "System.IO", "System.Linq", typeof(Config).Namespace);


### PR DESCRIPTION
This PR adds support for:
 - using  in memory assemblies in the configuration (this is very meta)
 - support for using Roslyn's `MetadataReference` instead/in conjunction with `Assembly` instance as input for the config file configuration

I can now have the following CSX file, with a class that doesn't exist:

```
Add("foo", new DynamicClass());
```

I can dynamically generate that missing class at runtime into memory, and feed into ConfigR:

```
                var compilation = CSharpCompilation.Create(
                    "DynamicAssembly", new[] {CSharpSyntaxTree.ParseText("public class DynamicClass {}")},
                    new[] {MetadataReference.CreateFromFile(typeof (object).Assembly.Location)},
                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));

                var metadata = compilation.ToMetadataReference();
                using (var ms = new MemoryStream())
                {
                    var cr = compilation.Emit(ms);
                    ms.Seek(0, SeekOrigin.Begin);
                    var assembly = Assembly.Load(ms.ToArray());

                    var config = Config.Global.Load(
                        new ScriptFileConfig(
                            @"foo.csx", new [] { assembly }, new [] { metadata }));
                    Console.WriteLine(Config.Global.Get<dynamic>("foo"));
                }
```

<!-- connects to https://github.com/config-r/config-r/issues/247 -->