### PR TITLE
Change HttpSourceFileResolver to be hybrid and resolves #loaded in me…

### DIFF
--- a/src/ConfigR.Roslyn.CSharp/ConfigR.Roslyn.CSharp.csproj
+++ b/src/ConfigR.Roslyn.CSharp/ConfigR.Roslyn.CSharp.csproj
@@ -108,6 +108,7 @@
       <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.0.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>

--- a/src/ConfigR.Roslyn.CSharp/Internal/HttpSourceFileResolver.cs
+++ b/src/ConfigR.Roslyn.CSharp/Internal/HttpSourceFileResolver.cs
@@ -5,28 +5,94 @@
 namespace ConfigR.Roslyn.CSharp.Internal
 {
     using System;
+    using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.IO;
+    using System.Net.Http;
+    using System.Text;
     using Microsoft.CodeAnalysis;
 
     [CLSCompliant(false)]
     public class HttpSourceFileResolver : SourceFileResolver, IEquatable<HttpSourceFileResolver>
     {
+        private readonly Dictionary<string, string> _remoteFiles = new Dictionary<string, string>();
+
         [CLSCompliant(false)]
         public HttpSourceFileResolver(ImmutableArray<string> searchPaths, string baseDirectory)
             : base(searchPaths, baseDirectory)
         {
         }
 
-        public override string ResolveReference(string path, string baseFilePath)
+        public bool Equals(HttpSourceFileResolver other)
         {
-            Uri uri;
-            return base.ResolveReference(
-                Uri.TryCreate(path, UriKind.Absolute, out uri) ? uri.ToFilePath() : path, baseFilePath);
+            var result = base.Equals(other);
+            return other == null ? result : result && Equals(_remoteFiles, other._remoteFiles);
         }
 
-        public bool Equals(HttpSourceFileResolver other) => base.Equals(other);
+        public override string ResolveReference(string path, string baseFilePath)
+        {
+            var uri = GetUri(path);
+            if (uri != null)
+            {
+                var client = new HttpClient();
+                var response = client.GetAsync(path).Result;
 
-        public override int GetHashCode() => base.GetHashCode();
+                if (response.IsSuccessStatusCode)
+                {
+                    var responseFile = response.Content.ReadAsStringAsync().Result;
+                    if (!string.IsNullOrWhiteSpace(responseFile))
+                    {
+                        _remoteFiles.Add(path, responseFile);
+                        return path;
+                    }
+                }
+            }
+
+            return base.ResolveReference(path, baseFilePath);
+        }
+
+        public override Stream OpenRead(string resolvedPath)
+        {
+            var uri = GetUri(resolvedPath);
+            if ((uri != null) && _remoteFiles.ContainsKey(resolvedPath))
+            {
+                var storedFile = _remoteFiles[resolvedPath];
+                return new MemoryStream(Encoding.UTF8.GetBytes(storedFile));
+            }
+
+            return base.OpenRead(resolvedPath);
+        }
+
+        public override string NormalizePath(string path, string baseFilePath)
+        {
+            var uri = GetUri(path);
+            if (uri == null)
+                return base.NormalizePath(path, baseFilePath);
+
+            return path;
+        }
+
+        private static Uri GetUri(string input)
+        {
+            Uri uriResult;
+            if (Uri.TryCreate(input, UriKind.Absolute, out uriResult)
+                && ((uriResult.Scheme == "http")
+                    || (uriResult.Scheme == "https")))
+                return uriResult;
+
+            return null;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = 37;
+                hashCode = (hashCode*397) ^ (_remoteFiles?.GetHashCode() ?? 0);
+                hashCode = (hashCode*397) ^ base.GetHashCode();
+                return hashCode;
+            }
+        }
 
         public override bool Equals(object obj) => base.Equals(obj);
     }

--- a/src/ConfigR.Roslyn.CSharp/Internal/HttpSourceFileResolver.cs
+++ b/src/ConfigR.Roslyn.CSharp/Internal/HttpSourceFileResolver.cs
@@ -15,7 +15,7 @@ namespace ConfigR.Roslyn.CSharp.Internal
     [CLSCompliant(false)]
     public class HttpSourceFileResolver : SourceFileResolver, IEquatable<HttpSourceFileResolver>
     {
-        private readonly Dictionary<string, string> _remoteFiles = new Dictionary<string, string>();
+        private readonly Dictionary<string, byte[]> _remoteFiles = new Dictionary<string, byte[]>();
 
         [CLSCompliant(false)]
         public HttpSourceFileResolver(ImmutableArray<string> searchPaths, string baseDirectory)
@@ -39,12 +39,8 @@ namespace ConfigR.Roslyn.CSharp.Internal
 
                 if (response.IsSuccessStatusCode)
                 {
-                    var responseFile = response.Content.ReadAsStringAsync().Result;
-                    if (!string.IsNullOrWhiteSpace(responseFile))
-                    {
-                        _remoteFiles.Add(path, responseFile);
-                        return path;
-                    }
+                    _remoteFiles.Add(path, response.Content.ReadAsByteArrayAsync().Result);
+                    return path;
                 }
             }
 
@@ -57,7 +53,7 @@ namespace ConfigR.Roslyn.CSharp.Internal
             if ((uri != null) && _remoteFiles.ContainsKey(resolvedPath))
             {
                 var storedFile = _remoteFiles[resolvedPath];
-                return new MemoryStream(Encoding.UTF8.GetBytes(storedFile));
+                return new MemoryStream(storedFile);
             }
 
             return base.OpenRead(resolvedPath);

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/SearchPathsFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/SearchPathsFeature.cs
@@ -64,6 +64,27 @@ namespace ConfigR.Tests.Acceptance
         }
 
         [Scenario]
+        public static void LoadingAScriptFromWeb(string foo)
+        {
+            dynamic config = null;
+            
+            "Given remote config file which loads the first file"
+                .f(c => ConfigFile.Create(
+                        $@"#load ""https://gist.githubusercontent.com/adamralph/9c4d6a6a705e1762646fbcf124f634f9/raw/d15f7331621e9065c566e94f32972546711ef29a/sample-config3.csx""")
+                    .Using(c));
+
+            "When I load the config file"
+                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+
+            "And I get WebGreeting"
+                .f(() => foo = config.WebGreeting<string>());
+
+            "Then Foo is 123"
+                .f(() => foo.Should().Be("Hello World from web!"));
+        }
+
+
+        [Scenario]
         public static void ReferencingAnAssemblyFromTheScriptFolder(string path1, string path2, Foo foo)
         {
             dynamic config = null;

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/SearchPathsFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/SearchPathsFeature.cs
@@ -73,7 +73,7 @@ namespace ConfigR.Tests.Acceptance
                         $@"#load ""https://gist.githubusercontent.com/adamralph/9c4d6a6a705e1762646fbcf124f634f9/raw/d15f7331621e9065c566e94f32972546711ef29a/sample-config3.csx""")
                     .Using(c));
 
-            "When I load the config file"
+            "When I load the config from web"
                 .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "And I get WebGreeting"


### PR DESCRIPTION
Change `HttpSourceFileResolver` to be hybrid and resolves `#loaded` in memory for web content.

Fix for https://github.com/config-r/config-r/issues/279