### PR TITLE
C# 7.1 and related changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ No pull request is too small. Even whitespace fixes are appreciated. Before you 
 
 ## How to build
 
-Navigate to your clone root folder and execute `build.cmd`. The only prerequisite you need is MSBuild 14, which is also included in Visual Studio 2015.
+Navigate to your clone root folder and execute `build.cmd`. The prerequisite you need is MSBuild 15, which is also included in Visual Studio 2017.
 
 `build.cmd` executes the default build targets which include compilation, test execution and packaging. After the build has completed, the build artifacts will be located in `artifacts/output/`.
 
-You can also build the solution using Visual Studio 2015 or later. At the time of writing the build is only confirmed to work on Windows using the Microsoft .NET framework.
+You can also build the solution using Visual Studio 2017 or later. At the time of writing the build is only confirmed to work on Windows using the Microsoft .NET framework 4.6+.
 
 ### Extras
 

--- a/build.cmd
+++ b/build.cmd
@@ -6,10 +6,10 @@ cd %~dp0
 setlocal
 
 :: determine cache dir
-set NUGET_CACHE_DIR=%LocalAppData%\.nuget\v3.5.0-rc1
+set NUGET_CACHE_DIR=%LocalAppData%\.nuget\v4.3.0-rc1
 
 :: download nuget to cache dir
-set NUGET_URL=https://dist.nuget.org/win-x86-commandline/v3.5.0-rc1/NuGet.exe
+set NUGET_URL=https://dist.nuget.org/win-x86-commandline/v4.3.0/nuget.exe
 if not exist %NUGET_CACHE_DIR%\NuGet.exe (
   if not exist %NUGET_CACHE_DIR% md %NUGET_CACHE_DIR%
   echo Downloading '%NUGET_URL%'' to '%NUGET_CACHE_DIR%\NuGet.exe'...

--- a/build.cmd
+++ b/build.cmd
@@ -23,7 +23,7 @@ if not exist .nuget\NuGet.exe (
 )
 
 :: restore packages
-.nuget\NuGet.exe restore .\ConfigR.sln -MSBuildVersion 14
+.nuget\NuGet.exe restore .\ConfigR.sln
 
 :: run script
-"%ProgramFiles(x86)%\MSBuild\14.0\Bin\csi.exe" .\build.csx %*
+"%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\Roslyn\csi.exe" .\build.csx %*

--- a/build.csx
+++ b/build.csx
@@ -18,7 +18,7 @@ var version = File.ReadAllText("src/CommonAssemblyInfo.cs")
 // locations
 var solution = "./ConfigR.sln";
 var logs = "./artifacts/logs";
-var msBuild = $"{Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}/MSBuild/14.0/Bin/msbuild.exe";
+var msBuild = $"{Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}/Microsoft Visual Studio/2017/Enterprise/MSBuild/15.0/Bin/msbuild.exe";
 var nuspecs = new[] { "./src/ConfigR/ConfigR.nuspec", "./src/ConfigR.Roslyn.CSharp/ConfigR.Roslyn.CSharp.nuspec", };
 var output = "./artifacts/output";
 var nuget = "./.nuget/NuGet.exe";

--- a/src/ConfigR.Roslyn.CSharp/App_Packages/LibLog.4.2/LibLog.cs
+++ b/src/ConfigR.Roslyn.CSharp/App_Packages/LibLog.4.2/LibLog.cs
@@ -422,11 +422,6 @@ namespace ConfigR.Roslyn.CSharp.Logging
     static class LogProvider
     {
 #if !LIBLOG_PROVIDERS_ONLY
-        /// <summary>
-        /// The disable logging environment variable. If the environment variable is set to 'true', then logging
-        /// will be disabled.
-        /// </summary>
-        public const string DisableLoggingEnvironmentVariable = "ConfigR.Roslyn.CSharp_LIBLOG_DISABLE";
         private const string NullLogProvider = "Current Log Provider is not set. Call SetCurrentLogProvider " +
                                                "with a non-null value first.";
         private static dynamic s_currentLogProvider;
@@ -517,15 +512,17 @@ namespace ConfigR.Roslyn.CSharp.Logging
         /// Gets a logger for the specified type.
         /// </summary>
         /// <param name="type">The type whose name will be used for the logger.</param>
+        /// <param name="fallbackTypeName">If the type is null then this name will be used as the log name instead</param>
         /// <returns>An instance of <see cref="ILog"/></returns>
 #if LIBLOG_PUBLIC
         public
 #else
         internal
 #endif
-        static ILog GetLogger(Type type)
+        static ILog GetLogger(Type type, string fallbackTypeName = "System.Object")
         {
-            return GetLogger(type.FullName);
+            // If the type passed in is null then fallback to the type name specified
+            return GetLogger(type != null ? type.FullName : fallbackTypeName);
         }
 
         /// <summary>
@@ -541,7 +538,7 @@ namespace ConfigR.Roslyn.CSharp.Logging
         static ILog GetLogger(string name)
         {
             ILogProvider logProvider = CurrentLogProvider ?? ResolveLogProvider();
-            return logProvider == null 
+            return logProvider == null
                 ? NoOpLogger.Instance
                 : (ILog)new LoggerExecutionWrapper(logProvider.GetLogger(name), () => IsDisabled);
         }
@@ -693,15 +690,6 @@ namespace ConfigR.Roslyn.CSharp.Logging
             {
                 return false;
             }
-#if !LIBLOG_PORTABLE
-            var envVar = Environment.GetEnvironmentVariable(LogProvider.DisableLoggingEnvironmentVariable);
-
-            if (envVar != null && envVar.Equals("true", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-#endif
-
             if (messageFunc == null)
             {
                 return _logger(logLevel, null);
@@ -757,7 +745,7 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
 
         protected LogProviderBase()
         {
-            _lazyOpenNdcMethod 
+            _lazyOpenNdcMethod
                 = new Lazy<OpenNdc>(GetOpenNdcMethod);
             _lazyOpenMdcMethod
                = new Lazy<OpenMdc>(GetOpenMdcMethod);
@@ -871,6 +859,55 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
         {
             private readonly dynamic _logger;
 
+            private static Func<string, object, string, Exception, object> _logEventInfoFact;
+
+            private static readonly object _levelTrace;
+            private static readonly object _levelDebug;
+            private static readonly object _levelInfo;
+            private static readonly object _levelWarn;
+            private static readonly object _levelError;
+            private static readonly object _levelFatal;
+
+            static NLogLogger()
+            {
+                try
+                {
+                    var logEventLevelType = Type.GetType("NLog.LogLevel, NLog");
+                    if (logEventLevelType == null)
+                    {
+                        throw new InvalidOperationException("Type NLog.LogLevel was not found.");
+                    }
+
+                    var levelFields = logEventLevelType.GetFieldsPortable().ToList();
+                    _levelTrace = levelFields.First(x => x.Name == "Trace").GetValue(null);
+                    _levelDebug = levelFields.First(x => x.Name == "Debug").GetValue(null);
+                    _levelInfo = levelFields.First(x => x.Name == "Info").GetValue(null);
+                    _levelWarn = levelFields.First(x => x.Name == "Warn").GetValue(null);
+                    _levelError = levelFields.First(x => x.Name == "Error").GetValue(null);
+                    _levelFatal = levelFields.First(x => x.Name == "Fatal").GetValue(null);
+
+                    var logEventInfoType = Type.GetType("NLog.LogEventInfo, NLog");
+                    if (logEventInfoType == null)
+                    {
+                        throw new InvalidOperationException("Type NLog.LogEventInfo was not found.");
+                    }
+                    MethodInfo createLogEventInfoMethodInfo = logEventInfoType.GetMethodPortable("Create",
+                        logEventLevelType, typeof(string), typeof(Exception), typeof(IFormatProvider), typeof(string), typeof(object[]));
+                    ParameterExpression loggerNameParam = Expression.Parameter(typeof(string));
+                    ParameterExpression levelParam = Expression.Parameter(typeof(object));
+                    ParameterExpression messageParam = Expression.Parameter(typeof(string));
+                    ParameterExpression exceptionParam = Expression.Parameter(typeof(Exception));
+                    UnaryExpression levelCast = Expression.Convert(levelParam, logEventLevelType);
+                    MethodCallExpression createLogEventInfoMethodCall = Expression.Call(null,
+                        createLogEventInfoMethodInfo,
+                        levelCast, loggerNameParam, exceptionParam,
+                        Expression.Constant(null, typeof(IFormatProvider)), messageParam, Expression.Constant(null, typeof(object[])));
+                    _logEventInfoFact = Expression.Lambda<Func<string, object, string, Exception, object>>(createLogEventInfoMethodCall,
+                        loggerNameParam, levelParam, messageParam, exceptionParam).Compile();
+                }
+                catch { }
+            }
+
             internal NLogLogger(dynamic logger)
             {
                 _logger = logger;
@@ -884,6 +921,43 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
                     return IsLogLevelEnable(logLevel);
                 }
                 messageFunc = LogMessageFormatter.SimulateStructuredLogging(messageFunc, formatParameters);
+
+                if (_logEventInfoFact != null)
+                {
+                    if (IsLogLevelEnable(logLevel))
+                    {
+                        var nlogLevel = this.TranslateLevel(logLevel);
+                        Type s_callerStackBoundaryType;
+#if !LIBLOG_PORTABLE
+                        StackTrace stack = new StackTrace();
+                        Type thisType = GetType();
+                        Type knownType0 = typeof(LoggerExecutionWrapper);
+                        Type knownType1 = typeof(LogExtensions);
+                        //Maybe inline, so we may can't found any LibLog classes in stack
+                        s_callerStackBoundaryType = null;
+                        for (var i = 0; i < stack.FrameCount; i++)
+                        {
+                            var declaringType = stack.GetFrame(i).GetMethod().DeclaringType;
+                            if (!IsInTypeHierarchy(thisType, declaringType) &&
+                                !IsInTypeHierarchy(knownType0, declaringType) &&
+                                !IsInTypeHierarchy(knownType1, declaringType))
+                            {
+                                if (i > 1)
+                                    s_callerStackBoundaryType = stack.GetFrame(i - 1).GetMethod().DeclaringType;
+                                break;
+                            }
+                        }
+#else
+                        s_callerStackBoundaryType = null;
+#endif
+                        if (s_callerStackBoundaryType != null)
+                            _logger.Log(s_callerStackBoundaryType, _logEventInfoFact(_logger.Name, nlogLevel, messageFunc(), exception));
+                        else
+                            _logger.Log(_logEventInfoFact(_logger.Name, nlogLevel, messageFunc(), exception));
+                        return true;
+                    }
+                    return false;
+                }
 
                 if(exception != null)
                 {
@@ -933,6 +1007,19 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
                             return true;
                         }
                         break;
+                }
+                return false;
+            }
+
+            private static bool IsInTypeHierarchy(Type currentType, Type checkType)
+            {
+                while (currentType != null && currentType != typeof(object))
+                {
+                    if (currentType == checkType)
+                    {
+                        return true;
+                    }
+                    currentType = currentType.GetBaseTypePortable();
                 }
                 return false;
             }
@@ -1004,6 +1091,27 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
                         return _logger.IsFatalEnabled;
                     default:
                         return _logger.IsTraceEnabled;
+                }
+            }
+
+            private object TranslateLevel(LogLevel logLevel)
+            {
+                switch (logLevel)
+                {
+                    case LogLevel.Trace:
+                        return _levelTrace;
+                    case LogLevel.Debug:
+                        return _levelDebug;
+                    case LogLevel.Info:
+                        return _levelInfo;
+                    case LogLevel.Warn:
+                        return _levelWarn;
+                    case LogLevel.Error:
+                        return _levelError;
+                    case LogLevel.Fatal:
+                        return _levelFatal;
+                    default:
+                        throw new ArgumentOutOfRangeException("logLevel", logLevel, null);
                 }
             }
         }
@@ -1129,7 +1237,9 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
             private readonly object _levelError;
             private readonly object _levelFatal;
             private readonly Func<object, object, bool> _isEnabledForDelegate;
-            private readonly Action<object, Type, object, string, Exception> _logDelegate;
+            private readonly Action<object, object> _logDelegate;
+            private readonly Func<object, Type, object, string, Exception, object> _createLoggingEvent;
+            private Action<object, string, object> _loggingEventPropertySetter;
 
             [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ILogger")]
             internal Log4NetLogger(dynamic logger)
@@ -1155,38 +1265,123 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
                 {
                     throw new InvalidOperationException("Type log4net.Core.ILogger, was not found.");
                 }
-                MethodInfo isEnabledMethodInfo = loggerType.GetMethodPortable("IsEnabledFor", logEventLevelType);
                 ParameterExpression instanceParam = Expression.Parameter(typeof(object));
                 UnaryExpression instanceCast = Expression.Convert(instanceParam, loggerType);
-                ParameterExpression callerStackBoundaryDeclaringTypeParam = Expression.Parameter(typeof(Type));
                 ParameterExpression levelParam = Expression.Parameter(typeof(object));
-                ParameterExpression messageParam = Expression.Parameter(typeof(string));
                 UnaryExpression levelCast = Expression.Convert(levelParam, logEventLevelType);
-                MethodCallExpression isEnabledMethodCall = Expression.Call(instanceCast, isEnabledMethodInfo, levelCast);
-                _isEnabledForDelegate = Expression.Lambda<Func<object, object, bool>>(isEnabledMethodCall, instanceParam, levelParam).Compile();
+                _isEnabledForDelegate = GetIsEnabledFor(loggerType, logEventLevelType, instanceCast, levelCast, instanceParam, levelParam);
 
-                // Action<object, object, string, Exception> Log =
-                // (logger, callerStackBoundaryDeclaringType, level, message, exception) => { ((ILogger)logger).Write(callerStackBoundaryDeclaringType, level, message, exception); }
+                Type loggingEventType = Type.GetType("log4net.Core.LoggingEvent, log4net");
+
+                _createLoggingEvent = GetCreateLoggingEvent(instanceParam, instanceCast, levelParam, levelCast, loggingEventType);
+
+                _logDelegate = GetLogDelegate(loggerType, loggingEventType, instanceCast, instanceParam);
+
+                _loggingEventPropertySetter = GetLoggingEventPropertySetter(loggingEventType);
+            }
+
+            private static Action<object, object> GetLogDelegate(Type loggerType, Type loggingEventType, UnaryExpression instanceCast,
+                                                 ParameterExpression instanceParam)
+            {
+                //Action<object, object, string, Exception> Log =
+                //(logger, callerStackBoundaryDeclaringType, level, message, exception) => { ((ILogger)logger).Log(new LoggingEvent(callerStackBoundaryDeclaringType, logger.Repository, logger.Name, level, message, exception)); }
                 MethodInfo writeExceptionMethodInfo = loggerType.GetMethodPortable("Log",
-                    typeof(Type),
-                    logEventLevelType,
-                    typeof(string),
-                    typeof(Exception));
-                ParameterExpression exceptionParam = Expression.Parameter(typeof(Exception));
+                                                                                   loggingEventType);
+
+                ParameterExpression loggingEventParameter =
+                    Expression.Parameter(typeof(object), "loggingEvent");
+
+                UnaryExpression loggingEventCasted =
+                    Expression.Convert(loggingEventParameter, loggingEventType);
+
                 var writeMethodExp = Expression.Call(
                     instanceCast,
                     writeExceptionMethodInfo,
-                    callerStackBoundaryDeclaringTypeParam,
-                    levelCast,
-                    messageParam,
-                    exceptionParam);
-                _logDelegate = Expression.Lambda<Action<object, Type, object, string, Exception>>(
-                    writeMethodExp,
-                    instanceParam,
-                    callerStackBoundaryDeclaringTypeParam,
-                    levelParam,
-                    messageParam,
-                    exceptionParam).Compile();
+                    loggingEventCasted);
+
+                var logDelegate = Expression.Lambda<Action<object, object>>(
+                                                writeMethodExp,
+                                                instanceParam,
+                                                loggingEventParameter).Compile();
+
+                return logDelegate;
+            }
+
+            private static Func<object, Type, object, string, Exception, object> GetCreateLoggingEvent(ParameterExpression instanceParam, UnaryExpression instanceCast, ParameterExpression levelParam, UnaryExpression levelCast, Type loggingEventType)
+            {
+                ParameterExpression callerStackBoundaryDeclaringTypeParam = Expression.Parameter(typeof(Type));
+                ParameterExpression messageParam = Expression.Parameter(typeof(string));
+                ParameterExpression exceptionParam = Expression.Parameter(typeof(Exception));
+
+                PropertyInfo repositoryProperty = loggingEventType.GetPropertyPortable("Repository");
+                PropertyInfo levelProperty = loggingEventType.GetPropertyPortable("Level");
+
+                ConstructorInfo loggingEventConstructor =
+                    loggingEventType.GetConstructorPortable(typeof(Type), repositoryProperty.PropertyType, typeof(string), levelProperty.PropertyType, typeof(object), typeof(Exception));
+
+                //Func<object, object, string, Exception, object> Log =
+                //(logger, callerStackBoundaryDeclaringType, level, message, exception) => new LoggingEvent(callerStackBoundaryDeclaringType, ((ILogger)logger).Repository, ((ILogger)logger).Name, (Level)level, message, exception); }
+                NewExpression newLoggingEventExpression =
+                    Expression.New(loggingEventConstructor,
+                                   callerStackBoundaryDeclaringTypeParam,
+                                   Expression.Property(instanceCast, "Repository"),
+                                   Expression.Property(instanceCast, "Name"),
+                                   levelCast,
+                                   messageParam,
+                                   exceptionParam);
+
+                var createLoggingEvent =
+                    Expression.Lambda<Func<object, Type, object, string, Exception, object>>(
+                                  newLoggingEventExpression,
+                                  instanceParam,
+                                  callerStackBoundaryDeclaringTypeParam,
+                                  levelParam,
+                                  messageParam,
+                                  exceptionParam)
+                              .Compile();
+
+                return createLoggingEvent;
+            }
+
+            private static Func<object, object, bool> GetIsEnabledFor(Type loggerType, Type logEventLevelType,
+                                                                      UnaryExpression instanceCast,
+                                                                      UnaryExpression levelCast,
+                                                                      ParameterExpression instanceParam,
+                                                                      ParameterExpression levelParam)
+            {
+                MethodInfo isEnabledMethodInfo = loggerType.GetMethodPortable("IsEnabledFor", logEventLevelType);
+                MethodCallExpression isEnabledMethodCall = Expression.Call(instanceCast, isEnabledMethodInfo, levelCast);
+
+                Func<object, object, bool> result =
+                    Expression.Lambda<Func<object, object, bool>>(isEnabledMethodCall, instanceParam, levelParam)
+                              .Compile();
+
+                return result;
+            }
+
+            private static Action<object, string, object> GetLoggingEventPropertySetter(Type loggingEventType)
+            {
+                ParameterExpression loggingEventParameter = Expression.Parameter(typeof(object), "loggingEvent");
+                ParameterExpression keyParameter = Expression.Parameter(typeof(string), "key");
+                ParameterExpression valueParameter = Expression.Parameter(typeof(object), "value");
+
+                PropertyInfo propertiesProperty = loggingEventType.GetPropertyPortable("Properties");
+                PropertyInfo item = propertiesProperty.PropertyType.GetPropertyPortable("Item");
+
+                // ((LoggingEvent)loggingEvent).Properties[key] = value;
+                var body =
+                    Expression.Assign(
+                        Expression.Property(
+                            Expression.Property(Expression.Convert(loggingEventParameter, loggingEventType),
+                                                propertiesProperty), item, keyParameter), valueParameter);
+
+                Action<object, string, object> result =
+                    Expression.Lambda<Action<object, string, object>>
+                              (body, loggingEventParameter, keyParameter,
+                               valueParameter)
+                              .Compile();
+
+                return result;
             }
 
             public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
@@ -1201,7 +1396,14 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
                     return false;
                 }
 
-                messageFunc = LogMessageFormatter.SimulateStructuredLogging(messageFunc, formatParameters);
+                string message = messageFunc();
+
+                IEnumerable<string> patternMatches;
+
+                string formattedMessage =
+                    LogMessageFormatter.FormatStructuredMessage(message,
+                                                                formatParameters,
+                                                                out patternMatches);
 
                 // determine correct caller - this might change due to jit optimizations with method inlining
                 if (s_callerStackBoundaryType == null)
@@ -1227,8 +1429,26 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
                 }
 
                 var translatedLevel = TranslateLevel(logLevel);
-                _logDelegate(_logger, s_callerStackBoundaryType, translatedLevel, messageFunc(), exception);
+
+                object loggingEvent = _createLoggingEvent(_logger, s_callerStackBoundaryType, translatedLevel, formattedMessage, exception);
+
+                PopulateProperties(loggingEvent, patternMatches, formatParameters);
+
+                _logDelegate(_logger, loggingEvent);
+
                 return true;
+            }
+
+            private void PopulateProperties(object loggingEvent, IEnumerable<string> patternMatches, object[] formatParameters)
+            {
+                IEnumerable<KeyValuePair<string, object>> keyToValue =
+                    patternMatches.Zip(formatParameters,
+                                       (key, value) => new KeyValuePair<string, object>(key, value));
+
+                foreach (KeyValuePair<string, object> keyValuePair in keyToValue)
+                {
+                    _loggingEventPropertySetter(loggingEvent, keyValuePair.Key, keyValuePair.Value);
+                }
             }
 
             private static bool IsInTypeHierarchy(Type currentType, Type checkType)
@@ -1373,7 +1593,7 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
             Expression severityParameter, ParameterExpression logNameParameter)
         {
             var entryType = LogEntryType;
-            MemberInitExpression memberInit = Expression.MemberInit(Expression.New(entryType), 
+            MemberInitExpression memberInit = Expression.MemberInit(Expression.New(entryType),
                 Expression.Bind(entryType.GetPropertyPortable("Message"), message),
                 Expression.Bind(entryType.GetPropertyPortable("Severity"), severityParameter),
                 Expression.Bind(
@@ -1489,12 +1709,15 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
 
         private static Func<string, string, IDisposable> GetPushProperty()
         {
-            Type ndcContextType = Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx");
+            Type ndcContextType = Type.GetType("Serilog.Context.LogContext, Serilog") ?? 
+                                  Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx");
+
             MethodInfo pushPropertyMethod = ndcContextType.GetMethodPortable(
                 "PushProperty", 
                 typeof(string),
                 typeof(object),
                 typeof(bool));
+
             ParameterExpression nameParam = Expression.Parameter(typeof(string), "name");
             ParameterExpression valueParam = Expression.Parameter(typeof(object), "value");
             ParameterExpression destructureObjectParam = Expression.Parameter(typeof(bool), "destructureObjects");
@@ -1849,7 +2072,12 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
 
     internal static class LogMessageFormatter
     {
-        private static readonly Regex Pattern = new Regex(@"\{@?\w{1,}\}");
+        //private static readonly Regex Pattern = new Regex(@"\{@?\w{1,}\}");
+#if LIBLOG_PORTABLE
+        private static readonly Regex Pattern = new Regex(@"(?<!{){@?(?<arg>[^\d{][^ }]*)}");
+#else
+        private static readonly Regex Pattern = new Regex(@"(?<!{){@?(?<arg>[^ :{}]+)(?<format>:[^}]+)?}", RegexOptions.Compiled);
+#endif
 
         /// <summary>
         /// Some logging frameworks support structured logging, such as serilog. This will allow you to add names to structured data in a format string:
@@ -1871,24 +2099,8 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
             return () =>
             {
                 string targetMessage = messageBuilder();
-                int argumentIndex = 0;
-                foreach (Match match in Pattern.Matches(targetMessage))
-                {
-                    int notUsed;
-                    if (!int.TryParse(match.Value.Substring(1, match.Value.Length -2), out notUsed))
-                    {
-                        targetMessage = ReplaceFirst(targetMessage, match.Value,
-                            "{" + argumentIndex++ + "}");
-                    }
-                }
-                try
-                {
-                    return string.Format(CultureInfo.InvariantCulture, targetMessage, formatParameters);
-                }
-                catch (FormatException ex)
-                {
-                    throw new FormatException("The input string '" + targetMessage + "' could not be formatted using string.Format", ex);
-                }
+                IEnumerable<string> patternMatches;
+                return FormatStructuredMessage(targetMessage, formatParameters, out patternMatches);
             };
         }
 
@@ -1901,10 +2113,62 @@ namespace ConfigR.Roslyn.CSharp.Logging.LogProviders
             }
             return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
         }
+
+        public static string FormatStructuredMessage(string targetMessage, object[] formatParameters, out IEnumerable<string> patternMatches)
+        {
+            if (formatParameters.Length == 0)
+            {
+                patternMatches = Enumerable.Empty<string>();
+                return targetMessage;
+            }
+
+            List<string> processedArguments = new List<string>();
+            patternMatches = processedArguments;
+
+            foreach (Match match in Pattern.Matches(targetMessage))
+            {
+                var arg = match.Groups["arg"].Value;
+
+                int notUsed;
+                if (!int.TryParse(arg, out notUsed))
+                {
+                    int argumentIndex = processedArguments.IndexOf(arg);
+                    if (argumentIndex == -1)
+                    {
+                        argumentIndex = processedArguments.Count;
+                        processedArguments.Add(arg);
+                    }
+
+                    targetMessage = ReplaceFirst(targetMessage, match.Value,
+                        "{" + argumentIndex + match.Groups["format"].Value + "}");
+                }
+            }
+            try
+            {
+                return string.Format(CultureInfo.InvariantCulture, targetMessage, formatParameters);
+            }
+            catch (FormatException ex)
+            {
+                throw new FormatException("The input string '" + targetMessage + "' could not be formatted using string.Format", ex);
+            }
+        }
     }
 
     internal static class TypeExtensions
     {
+        internal static ConstructorInfo GetConstructorPortable(this Type type, params Type[] types)
+        {
+#if LIBLOG_PORTABLE
+            return type.GetTypeInfo().DeclaredConstructors.FirstOrDefault
+                       (constructor =>
+                            constructor.GetParameters()
+                                       .Select(parameter => parameter.ParameterType)
+                                       .SequenceEqual(types));
+#else
+            return type.GetConstructor(types);
+#endif
+        }
+
         internal static MethodInfo GetMethodPortable(this Type type, string name)
         {
 #if LIBLOG_PORTABLE

--- a/src/ConfigR.Roslyn.CSharp/ConfigR.Roslyn.CSharp.csproj
+++ b/src/ConfigR.Roslyn.CSharp/ConfigR.Roslyn.CSharp.csproj
@@ -66,26 +66,25 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.4.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -108,8 +107,8 @@
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.5.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
@@ -124,13 +123,13 @@
       <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.4.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/src/ConfigR.Roslyn.CSharp/ConfigR.Roslyn.CSharp.csproj
+++ b/src/ConfigR.Roslyn.CSharp/ConfigR.Roslyn.CSharp.csproj
@@ -66,17 +66,17 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
@@ -129,8 +129,8 @@
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/src/ConfigR.Roslyn.CSharp/Internal/Loader.cs
+++ b/src/ConfigR.Roslyn.CSharp/Internal/Loader.cs
@@ -12,6 +12,9 @@ namespace ConfigR.Roslyn.CSharp.Internal
     using Microsoft.CodeAnalysis.CSharp.Scripting;
     using Microsoft.CodeAnalysis.Scripting;
     using Microsoft.CodeAnalysis.Scripting.Hosting;
+    using System.Reflection;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis;
 
     public class Loader : ILoader
     {
@@ -27,6 +30,7 @@ namespace ConfigR.Roslyn.CSharp.Internal
             this.scriptUri = scriptUri;
             this.options = options;
             this.assemblyLoader = assemblyLoader;
+            SetCSharpVersionToLatest();
         }
 
         public async Task<DynamicDictionary> Load(DynamicDictionary config)
@@ -39,6 +43,22 @@ namespace ConfigR.Roslyn.CSharp.Internal
                 .RunAsync(new ScriptGlobals(config));
 
             return config;
+        }
+
+        private void SetCSharpVersionToLatest()
+        {
+            try
+            {
+                // reset default scripting mode to latest language version to enable C# 7.1 features
+                // this is not needed once https://github.com/dotnet/roslyn/pull/21331 ships
+                var csharpScriptCompilerType = typeof(CSharpScript).GetTypeInfo().Assembly.GetType("Microsoft.CodeAnalysis.CSharp.Scripting.CSharpScriptCompiler");
+                var parseOptionsField = csharpScriptCompilerType?.GetField("s_defaultOptions", BindingFlags.Static | BindingFlags.NonPublic);
+                parseOptionsField?.SetValue(null, new CSharpParseOptions(LanguageVersion.Latest, kind: SourceCodeKind.Script));
+            }
+            catch (Exception)
+            {
+                log.Warn("Unable to set C# language version to latest, will use the default version.");
+            }
         }
     }
 }

--- a/src/ConfigR.Roslyn.CSharp/app.config
+++ b/src/ConfigR.Roslyn.CSharp/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.2.0" newVersion="1.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
@@ -36,7 +36,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.2.0" newVersion="1.4.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/ConfigR.Roslyn.CSharp/app.config
+++ b/src/ConfigR.Roslyn.CSharp/app.config
@@ -34,6 +34,10 @@
         <assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/ConfigR.Roslyn.CSharp/packages.config
+++ b/src/ConfigR.Roslyn.CSharp/packages.config
@@ -2,14 +2,14 @@
 <packages>
   <package id="LibLog" version="4.2.6" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.3.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.3.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="2.3.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.3.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net46" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
@@ -25,7 +25,7 @@
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.5.0" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
@@ -37,13 +37,13 @@
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
-  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding.CodePages" version="4.4.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />

--- a/src/ConfigR.Roslyn.CSharp/packages.config
+++ b/src/ConfigR.Roslyn.CSharp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LibLog" version="4.2.5" targetFramework="net46" developmentDependency="true" />
+  <package id="LibLog" version="4.2.6" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="2.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="2.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.1.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.2.0" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
@@ -29,7 +29,7 @@
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Runtime.Handles" version="4.0.0" targetFramework="net46" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
@@ -43,7 +43,7 @@
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/AnonymousTypesFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/AnonymousTypesFeature.cs
@@ -17,7 +17,7 @@ namespace ConfigR.Tests.Acceptance
             dynamic result = null;
 
             "Given a local config file containing an anonymous type with a Bar of 'baz'"
-                .f(c =>
+                .x(c =>
                 {
                     var code =
 @"using ConfigR.Tests.Acceptance.Roslyn.CSharp.Support;
@@ -28,13 +28,13 @@ Config.Foo = new { Bar = ""baz"" };
                 });
 
             "When I load the config"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "When I get the anonymous type"
-                .f(() => { result = config.Foo; });
+                .x(() => { result = config.Foo; });
 
             "Then the anonymous type has a Bar of 'baz'"
-                .f(() => ((string)result.Bar).Should().Be("baz"));
+                .x(() => ((string)result.Bar).Should().Be("baz"));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/CSharpLanguageVersionFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/CSharpLanguageVersionFeature.cs
@@ -1,0 +1,30 @@
+﻿using ConfigR.Tests.Acceptance.Roslyn.CSharp.Support;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xbehave;
+
+namespace ConfigR.Tests.Acceptance.Roslyn.CSharp
+{
+    public static class CSharpLanguageVersionFeature
+    {
+        [Scenario]
+        public static void NamedTuples(Foo foo)
+        {
+            "Given a local file which assigns property values from a named tuple ('a','b')"
+                .x(c => ConfigFile.Create(@"var a = ""a""; var b = ""b""; var tuple = (a,b); Config.Bar = tuple.a; Config.Baz = tuple.b;").Using(c));
+
+            "When I load the config as Foo"
+                .x(async () => foo = await new Config().UseRoslynCSharpLoader().Load<Foo>());
+
+            "Then the Foo has a Bar of 'a'"
+                .x(() => foo.Bar.Should().Be("a"));
+
+            "And the Foo has a Baz of 'b'"
+                .x(() => foo.Bar.Should().Be("a"));
+        }
+    }
+}

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
@@ -47,23 +47,22 @@
       <HintPath>..\..\packages\FluentAssertions.4.4.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.4.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -85,8 +84,8 @@
       <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.5.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
@@ -101,13 +100,13 @@
       <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.4.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
@@ -144,6 +144,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AnonymousTypesFeature.cs" />
+    <Compile Include="CSharpLanguageVersionFeature.cs" />
     <Compile Include="DynamicReferencesFeature.cs" />
     <Compile Include="TypeSyntaxFeature.cs" />
     <Compile Include="SeedingFeature.cs" />

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
@@ -47,14 +47,14 @@
       <HintPath>..\..\packages\FluentAssertions.4.4.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
@@ -106,8 +106,8 @@
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
@@ -35,6 +35,9 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FluentAssertions, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -39,13 +39,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.4.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.4.0\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.4.0\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions.Core, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
@@ -122,27 +120,24 @@
     <Reference Include="System.Xml.XPath.XDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
     </Reference>
-    <Reference Include="Xbehave.Core, Version=2.0.1.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xbehave.Core.2.0.1\lib\portable-net45\Xbehave.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Xbehave.Core, Version=2.1.4.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xbehave.Core.2.1.4\lib\portable-net45\Xbehave.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Xbehave.Execution.desktop, Version=2.0.1.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xbehave.Core.2.0.1\lib\portable-net45\Xbehave.Execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Xbehave.Execution.desktop, Version=2.1.4.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xbehave.Core.2.1.4\lib\portable-net45\Xbehave.Execution.desktop.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -195,6 +190,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
 </Project>

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ConfigR.Tests.Acceptance.Roslyn.CSharp.csproj
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -120,11 +118,11 @@
     <Reference Include="System.Xml.XPath.XDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
     </Reference>
-    <Reference Include="Xbehave.Core, Version=2.1.4.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xbehave.Core.2.1.4\lib\portable-net45\Xbehave.Core.dll</HintPath>
+    <Reference Include="Xbehave.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xbehave.Core.2.2.0-beta0003-build685\lib\net45\Xbehave.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Xbehave.Execution.desktop, Version=2.1.4.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xbehave.Core.2.1.4\lib\portable-net45\Xbehave.Execution.desktop.dll</HintPath>
+    <Reference Include="Xbehave.Execution.desktop, Version=2.2.0.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xbehave.Core.2.2.0-beta0003-build685\lib\net45\Xbehave.Execution.desktop.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
@@ -184,12 +182,5 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
     <Copy SourceFiles="..\ConfigR.Tests.Support.SampleDependency\bin\$(Configuration)\ConfigR.Tests.Support.SampleDependency.dll" DestinationFolder="$(OutputPath)" />
-  </Target>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
 </Project>

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/DefaultValuesFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/DefaultValuesFeature.cs
@@ -18,16 +18,16 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a config file with a Foo of 123"
-                .f(c => ConfigFile.Create("Config.Foo = 123;").Using(c));
+                .x(c => ConfigFile.Create("Config.Foo = 123;").Using(c));
 
             "When I load the file"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "And I get Foo with a default of 456"
-                .f(() => result = config.Foo<int>(456));
+                .x(() => result = config.Foo<int>(456));
 
             "Then the result is 123"
-                .f(() => result.Should().Be(123));
+                .x(() => result.Should().Be(123));
         }
 
         [Scenario]
@@ -36,16 +36,16 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a config file with a Foo of 123"
-                .f(c => ConfigFile.Create("Config.Foo = 123;").Using(c));
+                .x(c => ConfigFile.Create("Config.Foo = 123;").Using(c));
 
             "When I load the file"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "And I get Bar with a default of 456"
-                .f(() => result = config.Bar<int>(456));
+                .x(() => result = config.Bar<int>(456));
 
             "Then the result is 456"
-                .f(() => result.Should().Be(456));
+                .x(() => result.Should().Be(456));
         }
 
         [Scenario]
@@ -54,16 +54,16 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a config file with a Foo of 123"
-                .f(c => ConfigFile.Create("Config.Foo = 123;").Using(c));
+                .x(c => ConfigFile.Create("Config.Foo = 123;").Using(c));
 
             "When I load the file"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "And I get Bar with a default of 'abc'"
-                .f(() => exception = Record.Exception(() => config.Bar<int>("abc")));
+                .x(() => exception = Record.Exception(() => config.Bar<int>("abc")));
 
             "Then the exception indicates that 'abc' is the wrong type"
-                .f(() => exception.Message.Should().Contain("default is not").And.Contain("System.Int32"));
+                .x(() => exception.Message.Should().Contain("default is not").And.Contain("System.Int32"));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/DictionarySyntaxFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/DictionarySyntaxFeature.cs
@@ -17,16 +17,16 @@ namespace ConfigR.Tests.Acceptance.Roslyn.CSharp
             var config = default(IDictionary<string, object>);
 
             "Given a local config file with a Foo of 123"
-                .f(c => ConfigFile.Create(@"ConfigDictionary[""Foo""] = 123;").Using(c));
+                .x(c => ConfigFile.Create(@"ConfigDictionary[""Foo""] = 123;").Using(c));
 
             "When I load the config"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDictionary());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDictionary());
 
             "And I get Foo"
-                .f(() => result = config.Get<int>("Foo"));
+                .x(() => result = config.Get<int>("Foo"));
 
             "Then the result is 123"
-                .f(() => result.Should().Be(123));
+                .x(() => result.Should().Be(123));
         }
 
         [Scenario]
@@ -35,16 +35,16 @@ namespace ConfigR.Tests.Acceptance.Roslyn.CSharp
             var config = default(IDictionary<string, object>);
 
             "Given a local config file with a Foo of 123"
-                .f(c => ConfigFile.Create(@"ConfigDictionary[""Foo""] = 123;").Using(c));
+                .x(c => ConfigFile.Create(@"ConfigDictionary[""Foo""] = 123;").Using(c));
 
             "When I load the config"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDictionary());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDictionary());
 
             "And I get Bar with a default of 456"
-                .f(() => result = config.Get("Bar", 456));
+                .x(() => result = config.Get("Bar", 456));
 
             "Then the result is 456"
-                .f(() => result.Should().Be(456));
+                .x(() => result.Should().Be(456));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/DynamicReferencesFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/DynamicReferencesFeature.cs
@@ -27,7 +27,7 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given an assembly on disk which defines a Foo type"
-                .f(c =>
+                .x(c =>
                 {
                     var code =
 $@"namespace {c.Step.Scenario.ScenarioOutline.Method.Name}
@@ -53,7 +53,7 @@ $@"namespace {c.Step.Scenario.ScenarioOutline.Method.Name}
                 });
 
             "And config file with Foo with a Bar of 'baz'"
-                .f(c =>
+                .x(c =>
                 {
                     var code =
 $@"using {c.Step.Scenario.ScenarioOutline.Method.Name};
@@ -63,17 +63,17 @@ Config.Foo = new Foo {{ Bar = ""baz"" }};
                 });
 
             "When I load the assembly"
-                .f(c => reference = Assembly.Load(c.Step.Scenario.ScenarioOutline.Method.Name));
+                .x(c => reference = Assembly.Load(c.Step.Scenario.ScenarioOutline.Method.Name));
 
             "And I load the config using the assembly as a reference"
-                .f(async () => config = await new Config()
+                .x(async () => config = await new Config()
                     .UseRoslynCSharpLoader(options: ScriptOptions.Default.ForConfigScript().AddReferences(reference)).LoadDynamic());
 
             "And I get the value"
-                .f(() => result = config.Foo);
+                .x(() => result = config.Foo);
 
             "Then the Foo Bar should be 'baz'"
-                .f(() => ((string)((dynamic)result).Bar).Should().Be("baz"));
+                .x(() => ((string)((dynamic)result).Bar).Should().Be("baz"));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/EmptyConfigFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/EmptyConfigFeature.cs
@@ -22,13 +22,13 @@ namespace ConfigR.Tests.Acceptance
         public static void EmptyConfig(string code, Exception exception)
         {
             "Given a config file which contains no executable code"
-                .f(c => ConfigFile.Create(code).Using(c));
+                .x(c => ConfigFile.Create(code).Using(c));
 
             "When I load the config"
-                .f(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().LoadDynamic()));
+                .x(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().LoadDynamic()));
 
             "Then no exception is thrown"
-                .f(() => exception.Should().BeNull());
+                .x(() => exception.Should().BeNull());
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/FileConfigurationFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/FileConfigurationFeature.cs
@@ -16,7 +16,7 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a config file containing a Foo with a Bar of 'baz'"
-                .f(c =>
+                .x(c =>
                 {
                     var code =
 @"using ConfigR.Tests.Acceptance.Roslyn.CSharp.Support;
@@ -27,13 +27,13 @@ Config.Foo = new Foo { Bar = ""baz"" };
                 });
 
             "When I load the file"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader("foo.csx").LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader("foo.csx").LoadDynamic());
 
             "And I get the Foo"
-                .f(() => result = config.Foo<Foo>());
+                .x(() => result = config.Foo<Foo>());
 
             "Then the Foo has a Bar of 'baz'"
-                .f(() => result.Bar.Should().Be("baz"));
+                .x(() => result.Bar.Should().Be("baz"));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/LocalConfigurationFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/LocalConfigurationFeature.cs
@@ -19,7 +19,7 @@ namespace ConfigR.Tests.Acceptance.Roslyn.CSharp
             dynamic config = null;
 
             "Given a local config file containing a Foo with a Bar of 'baz'"
-                .f(c =>
+                .x(c =>
                 {
                     var code =
 @"using ConfigR.Tests.Acceptance.Roslyn.CSharp.Support;
@@ -30,62 +30,62 @@ Config.Foo = new Foo { Bar = ""baz"" };
                 });
 
             "When I load the config"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "And I get the Foo"
-                .f(() => result = config.Foo<Foo>());
+                .x(() => result = config.Foo<Foo>());
 
             "Then the Foo has a Bar of 'baz'"
-                .f(() => result.Bar.Should().Be("baz"));
+                .x(() => result.Bar.Should().Be("baz"));
         }
 
         [Scenario]
         public static void ScriptFailsToCompile(Exception exception)
         {
             "Given a local config file which fails to compile"
-                .f(c => ConfigFile.Create(@"This is not C#!").Using(c));
+                .x(c => ConfigFile.Create(@"This is not C#!").Using(c));
 
             "When I load the config file"
-                .f(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().LoadDynamic()));
+                .x(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().LoadDynamic()));
 
             "Then an exception is thrown"
-                .f(() => exception.Should().NotBeNull());
+                .x(() => exception.Should().NotBeNull());
 
             "And the exception should be a compilation error exception"
-                .f(() => exception.GetType().Name.Should().Be("CompilationErrorException"));
+                .x(() => exception.GetType().Name.Should().Be("CompilationErrorException"));
         }
 
         [Scenario]
         public static void ScriptFailsToExecute(Exception exception)
         {
             "Given a local config file which throws an exception with the message 'Boo!'"
-                .f(c => ConfigFile.Create(@"throw new System.Exception(""Boo!"");").Using(c));
+                .x(c => ConfigFile.Create(@"throw new System.Exception(""Boo!"");").Using(c));
 
             "When I load the config file"
-                .f(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().LoadDynamic()));
+                .x(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().LoadDynamic()));
 
             "Then an exception is thrown"
-                .f(() => exception.Should().NotBeNull());
+                .x(() => exception.Should().NotBeNull());
 
             "And the exception message is 'Boo!'"
-                .f(() => exception.Message.Should().Be("Boo!"));
+                .x(() => exception.Message.Should().Be("Boo!"));
         }
 
         [Scenario]
         public static void ConfigurationFileIsNull(Exception exception)
         {
             "Given the app domain configuration file is null"
-                .f(c => AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", null))
+                .x(c => AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", null))
                 .Teardown(() => AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", Path.GetFileName(ConfigFile.GetDefaultPath())));
 
             "When I load the config file"
-                .f(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().LoadDynamic()));
+                .x(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().LoadDynamic()));
 
             "Then an invalid operation exception is thrown"
-                .f(() => exception.Should().NotBeNull());
+                .x(() => exception.Should().NotBeNull());
 
             "And the exception message tells us that the app domain config file is null"
-                .f(() => exception.Message.Should().Be("AppDomain.CurrentDomain.SetupInformation.ConfigurationFile is null."));
+                .x(() => exception.Message.Should().Be("AppDomain.CurrentDomain.SetupInformation.ConfigurationFile is null."));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/MultipleLoadersFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/MultipleLoadersFeature.cs
@@ -16,20 +16,20 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a config file with a Foo of 123"
-                .f(c => ConfigFile.Create("Config.Foo = 123;", "foo.csx").Using(c));
+                .x(c => ConfigFile.Create("Config.Foo = 123;", "foo.csx").Using(c));
 
             "And another config file with a Foo of 456"
-                .f(c => ConfigFile.Create("Config.Foo = 456;", "bar.csx").Using(c));
+                .x(c => ConfigFile.Create("Config.Foo = 456;", "bar.csx").Using(c));
 
             "When I load the first file followed by the second file"
-                .f(async () => config = await new Config()
+                .x(async () => config = await new Config()
                     .UseRoslynCSharpLoader("foo.csx").UseRoslynCSharpLoader("bar.csx").LoadDynamic());
 
             "And I get Foo"
-                .f(() => foo = config.Foo<int>());
+                .x(() => foo = config.Foo<int>());
 
             "Then Foo is 456"
-                .f(() => foo.Should().Be(456));
+                .x(() => foo.Should().Be(456));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/SearchPathsFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/SearchPathsFeature.cs
@@ -18,25 +18,25 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a remote config file with a Foo of 123"
-                .f(c => ConfigFile.Create(
+                .x(c => ConfigFile.Create(
                         "Config.Foo = 123;",
                         path1 = Path.Combine(Path.GetTempPath(), Path.GetTempFileName()))
                     .Using(c));
 
             "And another remote config file in the same folder, which loads the first file"
-                .f(c => ConfigFile.Create(
+                .x(c => ConfigFile.Create(
                         $@"#load ""{Path.GetFileName(path1)}""",
                         path2 = Path.Combine(Path.GetTempPath(), Path.GetTempFileName()))
                     .Using(c));
 
             "When I load the second config file"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader(path2).LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader(path2).LoadDynamic());
 
             "And I get Foo"
-                .f(() => foo = config.Foo<int>());
+                .x(() => foo = config.Foo<int>());
 
             "Then Foo is 123"
-                .f(() => foo.Should().Be(123));
+                .x(() => foo.Should().Be(123));
         }
 
         [Scenario]
@@ -45,22 +45,22 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a local config file with a Foo of 123"
-                .f(c => ConfigFile.Create("Config.Foo = 123;", path1 = "foo.csx").Using(c));
+                .x(c => ConfigFile.Create("Config.Foo = 123;", path1 = "foo.csx").Using(c));
 
             "And remote config file which loads the first file"
-                .f(c => ConfigFile.Create(
+                .x(c => ConfigFile.Create(
                         $@"#load ""foo.csx""",
                         path2 = Path.Combine(Path.GetTempPath(), Path.GetTempFileName()))
                     .Using(c));
 
             "When I load the second config file"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader(path2).LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader(path2).LoadDynamic());
 
             "And I get Foo"
-                .f(() => foo = config.Foo<int>());
+                .x(() => foo = config.Foo<int>());
 
             "Then Foo is 123"
-                .f(() => foo.Should().Be(123));
+                .x(() => foo.Should().Be(123));
         }
 
         [Scenario]
@@ -69,18 +69,18 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
             
             "Given remote config file which loads the first file"
-                .f(c => ConfigFile.Create(
+                .x(c => ConfigFile.Create(
                         $@"#load ""https://gist.githubusercontent.com/adamralph/9c4d6a6a705e1762646fbcf124f634f9/raw/d15f7331621e9065c566e94f32972546711ef29a/sample-config3.csx""")
                     .Using(c));
 
             "When I load the config from web"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "And I get WebGreeting"
-                .f(() => foo = config.WebGreeting<string>());
+                .x(() => foo = config.WebGreeting<string>());
 
             "Then Foo is 123"
-                .f(() => foo.Should().Be("Hello World from web!"));
+                .x(() => foo.Should().Be("Hello World from web!"));
         }
 
 
@@ -90,13 +90,13 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a remote assembly"
-                .f(c => File.Copy(
+                .x(c => File.Copy(
                     "ConfigR.Tests.Support.SampleDependency.dll",
                     path1 = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetTempFileName(), "dll")),
                     true));
 
             "And a remote config file in the same folder, which references the assembly"
-                .f(c =>
+                .x(c =>
                 {
                     var code =
 $@"#r ""{Path.GetFileName(path1)}""
@@ -108,13 +108,13 @@ Config.Foo = new Foo {{ Bar = ""baz"" }};
                 });
 
             "When I load the config file"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader(path2).LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader(path2).LoadDynamic());
 
             "And I get Foo"
-                .f(() => foo = config.Foo<Foo>());
+                .x(() => foo = config.Foo<Foo>());
 
             "Then Foo has a Bar of 'baz'"
-                .f(() => foo.Bar.Should().Be("baz"));
+                .x(() => foo.Bar.Should().Be("baz"));
         }
 
         [Scenario]
@@ -123,7 +123,7 @@ Config.Foo = new Foo {{ Bar = ""baz"" }};
             dynamic config = null;
 
             "Given a remote config file which references a local assembly"
-                .f(c =>
+                .x(c =>
                 {
                     var code =
 $@"#r ""ConfigR.Tests.Support.SampleDependency.dll""
@@ -140,13 +140,13 @@ Config.Foo = new Foo {{ Bar = ""baz"" }};
                 });
 
             "When I load the config file"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader(path).LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader(path).LoadDynamic());
 
             "And I get Foo"
-                .f(() => foo = config.Foo<Foo>());
+                .x(() => foo = config.Foo<Foo>());
 
             "Then Foo has a Bar of 'baz'"
-                .f(() => foo.Bar.Should().Be("baz"));
+                .x(() => foo.Bar.Should().Be("baz"));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/SeedingFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/SeedingFeature.cs
@@ -17,16 +17,16 @@ namespace ConfigR.Tests.Acceptance.Roslyn.CSharp
             dynamic config = null;
 
             "Given a local config file which sets Foo using the value of Bar"
-                .f(c => ConfigFile.Create(@"Config.Foo = Config.Bar;").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Foo = Config.Bar;").Using(c));
 
             "And I load the config seeded with Bar set to 'baz'"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic(new { Bar = "baz" }));
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic(new { Bar = "baz" }));
 
             "And I get Foo"
-                .f(() => result = config.Foo<string>());
+                .x(() => result = config.Foo<string>());
 
             "Then Foo is 'baz'"
-                .f(() => result.Should().Be("baz"));
+                .x(() => result.Should().Be("baz"));
         }
 
         [Scenario]
@@ -35,16 +35,16 @@ namespace ConfigR.Tests.Acceptance.Roslyn.CSharp
             dynamic config = null;
 
             "Given a local config file which sets Foo using the value of Bar"
-                .f(c => ConfigFile.Create(@"Config.Foo = Config.Bar;").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Foo = Config.Bar;").Using(c));
 
             "And I load the config seeded with Bar set to 'baz'"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic(new Dictionary<string, object> { { "Bar", "baz" } }));
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic(new Dictionary<string, object> { { "Bar", "baz" } }));
 
             "And I get Foo"
-                .f(() => result = config.Foo<string>());
+                .x(() => result = config.Foo<string>());
 
             "Then Foo is 'baz'"
-                .f(() => result.Should().Be("baz"));
+                .x(() => result.Should().Be("baz"));
         }
 
         [Scenario]
@@ -53,16 +53,16 @@ namespace ConfigR.Tests.Acceptance.Roslyn.CSharp
             IDictionary<string, object> config = null;
 
             "Given a local config file which sets Foo using the value of Bar"
-                .f(c => ConfigFile.Create(@"Config.Foo = Config.Bar;").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Foo = Config.Bar;").Using(c));
 
             "And I load the config seeded with Bar set to 'baz'"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDictionary(new { Bar = "baz" }));
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDictionary(new { Bar = "baz" }));
 
             "And I get Foo"
-                .f(() => result = config.Get<string>("Foo"));
+                .x(() => result = config.Get<string>("Foo"));
 
             "Then Foo is 'baz'"
-                .f(() => result.Should().Be("baz"));
+                .x(() => result.Should().Be("baz"));
         }
 
         [Scenario]
@@ -71,16 +71,16 @@ namespace ConfigR.Tests.Acceptance.Roslyn.CSharp
             IDictionary<string, object> config = null;
 
             "Given a local config file which sets Foo using the value of Bar"
-                .f(c => ConfigFile.Create(@"Config.Foo = Config.Bar;").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Foo = Config.Bar;").Using(c));
 
             "And I load the config seeded with Bar set to 'baz'"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDictionary(new Dictionary<string, object> { { "Bar", "baz" } }));
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDictionary(new Dictionary<string, object> { { "Bar", "baz" } }));
 
             "And I get Foo"
-                .f(() => result = config.Get<string>("Foo"));
+                .x(() => result = config.Get<string>("Foo"));
 
             "Then Foo is 'baz'"
-                .f(() => result.Should().Be("baz"));
+                .x(() => result.Should().Be("baz"));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/StaticTypingFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/StaticTypingFeature.cs
@@ -18,25 +18,25 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a config file with a Foo string"
-                .f(c => ConfigFile.Create(@"Config.Foo = ""abc"";").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Foo = ""abc"";").Using(c));
 
             "When I load the file"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "And I try to get an integer named 'foo'"
-                .f(() => ex = Record.Exception(() => config.Foo<int>()));
+                .x(() => ex = Record.Exception(() => config.Foo<int>()));
 
             "Then an exception is thrown"
-                .f(() => ex.Should().NotBeNull());
+                .x(() => ex.Should().NotBeNull());
 
             "And the exception message contains 'Foo'"
-                .f(() => ex.Message.Should().Contain("Foo"));
+                .x(() => ex.Message.Should().Contain("Foo"));
 
             "And the exception message contains the full type name of int"
-                .f(() => ex.Message.Should().Contain(typeof(int).FullName));
+                .x(() => ex.Message.Should().Contain(typeof(int).FullName));
 
             "And the exception message contains the full type name of string"
-                .f(() => ex.Message.Should().Contain(typeof(string).FullName));
+                .x(() => ex.Message.Should().Contain(typeof(string).FullName));
         }
 
         [Scenario]
@@ -45,25 +45,25 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a config file with a Foo null"
-                .f(c => ConfigFile.Create(@"Config.Foo = null;").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Foo = null;").Using(c));
 
             "When I load the file"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "And I try to get an integer named 'foo'"
-                .f(() => ex = Record.Exception(() => config.Foo<int>()));
+                .x(() => ex = Record.Exception(() => config.Foo<int>()));
 
             "Then an exception is thrown"
-                .f(() => ex.Should().NotBeNull());
+                .x(() => ex.Should().NotBeNull());
 
             "And the exception message contains 'Foo'"
-                .f(() => ex.Message.Should().Contain("Foo"));
+                .x(() => ex.Message.Should().Contain("Foo"));
 
             "And the exception message contains the full type name of int"
-                .f(() => ex.Message.Should().Contain(typeof(int).FullName));
+                .x(() => ex.Message.Should().Contain(typeof(int).FullName));
 
             "And the exception message contains 'null'"
-                .f(() => ex.Message.Should().Contain("null"));
+                .x(() => ex.Message.Should().Contain("null"));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/Support/ConfigFile.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/Support/ConfigFile.cs
@@ -31,7 +31,7 @@ namespace ConfigR.Tests.Acceptance.Roslyn.CSharp.Support
         }
 
         private sealed class Disposable : IDisposable
-        {
+        {   
             private readonly Action whenDisposed;
 
             public Disposable(Action whenDisposed)

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/TypeSyntaxFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/TypeSyntaxFeature.cs
@@ -17,78 +17,78 @@ namespace ConfigR.Tests.Acceptance.Roslyn.CSharp
         public static void UsingTypeSyntax(Foo foo)
         {
             "Given a local config file with a Bar of 'abc'"
-                .f(c => ConfigFile.Create(@"Config.Bar = ""abc"";").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Bar = ""abc"";").Using(c));
 
             "When I load the config as Foo"
-                .f(async () => foo = await new Config().UseRoslynCSharpLoader().Load<Foo>());
+                .x(async () => foo = await new Config().UseRoslynCSharpLoader().Load<Foo>());
 
             "Then the Foo has a Bar of 'abc'"
-                .f(() => foo.Bar.Should().Be("abc"));
+                .x(() => foo.Bar.Should().Be("abc"));
         }
 
         [Scenario]
         public static void UsingTypeSyntaxWithAnObjectSeed(Foo foo)
         {
             "Given a local config file with a Bar of 'abc'"
-                .f(c => ConfigFile.Create(@"Config.Bar = ""abc"";").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Bar = ""abc"";").Using(c));
 
             "When I load the config as Foo with an object seed with a Baz of 'def'"
-                .f(async () => foo = await new Config().UseRoslynCSharpLoader().Load<Foo>(new { Baz = "def" }));
+                .x(async () => foo = await new Config().UseRoslynCSharpLoader().Load<Foo>(new { Baz = "def" }));
 
             "Then the Foo has a Bar of 'abc'"
-                .f(() => foo.Bar.Should().Be("abc"));
+                .x(() => foo.Bar.Should().Be("abc"));
 
             "And the Foo has a Baz of 'def'"
-                .f(() => foo.Baz.Should().Be("def"));
+                .x(() => foo.Baz.Should().Be("def"));
         }
 
         [Scenario]
         public static void UsingTypeSyntaxWithADictionarSeed(Foo foo)
         {
             "Given a local config file with a Bar of 'abc'"
-                .f(c => ConfigFile.Create(@"Config.Bar = ""abc"";").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Bar = ""abc"";").Using(c));
 
             "When I load the config as Foo with a dictionary seed with a Baz of 'def'"
-                .f(async () =>
+                .x(async () =>
                 {
                     var seed = new Dictionary<string, object>() { { "Baz", "def" } };
                     foo = await new Config().UseRoslynCSharpLoader().Load<Foo>(seed);
                 });
 
             "Then the Foo has a Bar of 'abc'"
-                .f(() => foo.Bar.Should().Be("abc"));
+                .x(() => foo.Bar.Should().Be("abc"));
 
             "And the Foo has a Baz of 'def'"
-                .f(() => foo.Baz.Should().Be("def"));
+                .x(() => foo.Baz.Should().Be("def"));
         }
 
         [Scenario]
         public static void UsingTypeSyntaxWithRedundantValues(Exception exception)
         {
             "Given a local config file with a Bazz of 'def'"
-                .f(c => ConfigFile.Create(@"Config.Bazz = ""def""").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Bazz = ""def""").Using(c));
 
             "When I load the config as Foo"
-                .f(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().Load<Foo>()));
+                .x(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().Load<Foo>()));
 
             "Then no exception is thrown"
-                .f(() => exception.Should().BeNull());
+                .x(() => exception.Should().BeNull());
         }
 
         [Scenario]
         public static void UsingTypeSyntaxWithBadlyTypedValues(Exception exception)
         {
             "Given a local config file with a Bar of 42"
-                .f(c => ConfigFile.Create(@"Config.Bar = 42;").Using(c));
+                .x(c => ConfigFile.Create(@"Config.Bar = 42;").Using(c));
 
             "When I load the config as Foo"
-                .f(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().Load<Foo>()));
+                .x(async () => exception = await Record.ExceptionAsync(async () => await new Config().UseRoslynCSharpLoader().Load<Foo>()));
 
             "Then an exception is thrown"
-                .f(() => exception.Should().NotBeNull());
+                .x(() => exception.Should().NotBeNull());
 
             "And the exception message contains 'Bar'"
-                .f(() => exception.Message.Should().Contain("Bar"));
+                .x(() => exception.Message.Should().Contain("Bar"));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ValueRetreivalFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/ValueRetreivalFeature.cs
@@ -18,19 +18,19 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a local config file containing Foo of 42"
-                .f(c => ConfigFile.Create("Config.Foo = 42;").Using(c));
+                .x(c => ConfigFile.Create("Config.Foo = 42;").Using(c));
 
             "When I load the config"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "And I get Bar"
-                .f(() => exception = Record.Exception(() => config.Bar<int>()));
+                .x(() => exception = Record.Exception(() => config.Bar<int>()));
 
             "Then an exception is thrown"
-                .f(() => exception.Should().NotBeNull());
+                .x(() => exception.Should().NotBeNull());
 
             "And the exception indicates that Bar does not exist"
-                .f(() => exception.Message.Should().Contain("'Bar' does not exist"));
+                .x(() => exception.Message.Should().Contain("'Bar' does not exist"));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/VisualStudioHostingFeature.cs
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/VisualStudioHostingFeature.cs
@@ -19,7 +19,7 @@ namespace ConfigR.Tests.Acceptance
             dynamic config = null;
 
             "Given a local config file containing Foo of 42"
-                .f(c => ConfigFile.Create("Config.Foo = 42;").Using(c));
+                .x(c => ConfigFile.Create("Config.Foo = 42;").Using(c));
 
             "And we are using Visual Studio hosting"
                 .x(() =>
@@ -37,13 +37,13 @@ namespace ConfigR.Tests.Acceptance
                 .Teardown(() => AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", Path.GetFileName(ConfigFile.GetDefaultPath())));
 
             "When I load the config"
-                .f(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
+                .x(async () => config = await new Config().UseRoslynCSharpLoader().LoadDynamic());
 
             "And I get Foo"
-                .f(() => result = config.Foo<int>());
+                .x(() => result = config.Foo<int>());
 
             "Then Foo is 42"
-                .f(() => result.Should().Be(42));
+                .x(() => result.Should().Be(42));
         }
     }
 }

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/app.config
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/app.config
@@ -8,19 +8,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Scripting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.2.0" newVersion="1.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
@@ -52,7 +52,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.2.0" newVersion="1.4.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/app.config
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/app.config
@@ -8,15 +8,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Scripting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -49,6 +49,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/app.config
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/app.config
@@ -62,6 +62,10 @@
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.4.2.0" newVersion="1.4.2.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/app.config
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/app.config
@@ -8,15 +8,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Scripting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -64,6 +64,10 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
       </dependentAssembly>
     </assemblyBinding>

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/packages.config
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.4.0" targetFramework="net46" />
+  <package id="FluentAssertions" version="4.19.3" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.3.1" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.3.1" targetFramework="net46" />
@@ -48,13 +48,13 @@
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XPath" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net46" />
-  <package id="Xbehave" version="2.0.1" targetFramework="net46" />
-  <package id="Xbehave.Core" version="2.0.1" targetFramework="net46" />
-  <package id="xunit" version="2.1.0" targetFramework="net46" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net46" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net46" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net46" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net46" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net46" />
+  <package id="Xbehave" version="2.1.4" targetFramework="net46" />
+  <package id="Xbehave.Core" version="2.1.4" targetFramework="net46" />
+  <package id="xunit" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net46" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/packages.config
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/packages.config
@@ -48,13 +48,14 @@
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XPath" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net46" />
-  <package id="Xbehave" version="2.1.4" targetFramework="net46" />
-  <package id="Xbehave.Core" version="2.1.4" targetFramework="net46" />
+  <package id="Xbehave" version="2.2.0-beta0003-build685" targetFramework="net46" />
+  <package id="Xbehave.Core" version="2.2.0-beta0003-build685" targetFramework="net46" />
   <package id="xunit" version="2.2.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net46" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net46" />
   <package id="xunit.core" version="2.2.0" targetFramework="net46" />
   <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net46" />
   <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.runner.console" version="2.2.0" targetFramework="net46" developmentDependency="true" />
   <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/packages.config
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="FluentAssertions" version="4.4.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="2.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.1.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.2.0" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
@@ -28,7 +28,7 @@
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Runtime.Handles" version="4.0.0" targetFramework="net46" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
@@ -42,7 +42,7 @@
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/packages.config
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/packages.config
@@ -2,13 +2,13 @@
 <packages>
   <package id="FluentAssertions" version="4.4.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.3.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.3.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.3.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net46" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
@@ -24,7 +24,7 @@
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.5.0" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
@@ -36,13 +36,13 @@
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
-  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding.CodePages" version="4.4.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />

--- a/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/xunit.runner.json
+++ b/tests/ConfigR.Tests.Acceptance.Roslyn.CSharp/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "parallelizeTestCollections": false
+}

--- a/tests/ConfigR.Tests.Smoke.Service/App_Packages/LibLog.4.2/LibLog.cs
+++ b/tests/ConfigR.Tests.Smoke.Service/App_Packages/LibLog.4.2/LibLog.cs
@@ -422,11 +422,6 @@ namespace ConfigR.Tests.Smoke.Service.Logging
     static class LogProvider
     {
 #if !LIBLOG_PROVIDERS_ONLY
-        /// <summary>
-        /// The disable logging environment variable. If the environment variable is set to 'true', then logging
-        /// will be disabled.
-        /// </summary>
-        public const string DisableLoggingEnvironmentVariable = "ConfigR.Tests.Smoke.Service_LIBLOG_DISABLE";
         private const string NullLogProvider = "Current Log Provider is not set. Call SetCurrentLogProvider " +
                                                "with a non-null value first.";
         private static dynamic s_currentLogProvider;
@@ -517,15 +512,17 @@ namespace ConfigR.Tests.Smoke.Service.Logging
         /// Gets a logger for the specified type.
         /// </summary>
         /// <param name="type">The type whose name will be used for the logger.</param>
+        /// <param name="fallbackTypeName">If the type is null then this name will be used as the log name instead</param>
         /// <returns>An instance of <see cref="ILog"/></returns>
 #if LIBLOG_PUBLIC
         public
 #else
         internal
 #endif
-        static ILog GetLogger(Type type)
+        static ILog GetLogger(Type type, string fallbackTypeName = "System.Object")
         {
-            return GetLogger(type.FullName);
+            // If the type passed in is null then fallback to the type name specified
+            return GetLogger(type != null ? type.FullName : fallbackTypeName);
         }
 
         /// <summary>
@@ -541,7 +538,7 @@ namespace ConfigR.Tests.Smoke.Service.Logging
         static ILog GetLogger(string name)
         {
             ILogProvider logProvider = CurrentLogProvider ?? ResolveLogProvider();
-            return logProvider == null 
+            return logProvider == null
                 ? NoOpLogger.Instance
                 : (ILog)new LoggerExecutionWrapper(logProvider.GetLogger(name), () => IsDisabled);
         }
@@ -693,15 +690,6 @@ namespace ConfigR.Tests.Smoke.Service.Logging
             {
                 return false;
             }
-#if !LIBLOG_PORTABLE
-            var envVar = Environment.GetEnvironmentVariable(LogProvider.DisableLoggingEnvironmentVariable);
-
-            if (envVar != null && envVar.Equals("true", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-#endif
-
             if (messageFunc == null)
             {
                 return _logger(logLevel, null);
@@ -757,7 +745,7 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
 
         protected LogProviderBase()
         {
-            _lazyOpenNdcMethod 
+            _lazyOpenNdcMethod
                 = new Lazy<OpenNdc>(GetOpenNdcMethod);
             _lazyOpenMdcMethod
                = new Lazy<OpenMdc>(GetOpenMdcMethod);
@@ -871,6 +859,55 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
         {
             private readonly dynamic _logger;
 
+            private static Func<string, object, string, Exception, object> _logEventInfoFact;
+
+            private static readonly object _levelTrace;
+            private static readonly object _levelDebug;
+            private static readonly object _levelInfo;
+            private static readonly object _levelWarn;
+            private static readonly object _levelError;
+            private static readonly object _levelFatal;
+
+            static NLogLogger()
+            {
+                try
+                {
+                    var logEventLevelType = Type.GetType("NLog.LogLevel, NLog");
+                    if (logEventLevelType == null)
+                    {
+                        throw new InvalidOperationException("Type NLog.LogLevel was not found.");
+                    }
+
+                    var levelFields = logEventLevelType.GetFieldsPortable().ToList();
+                    _levelTrace = levelFields.First(x => x.Name == "Trace").GetValue(null);
+                    _levelDebug = levelFields.First(x => x.Name == "Debug").GetValue(null);
+                    _levelInfo = levelFields.First(x => x.Name == "Info").GetValue(null);
+                    _levelWarn = levelFields.First(x => x.Name == "Warn").GetValue(null);
+                    _levelError = levelFields.First(x => x.Name == "Error").GetValue(null);
+                    _levelFatal = levelFields.First(x => x.Name == "Fatal").GetValue(null);
+
+                    var logEventInfoType = Type.GetType("NLog.LogEventInfo, NLog");
+                    if (logEventInfoType == null)
+                    {
+                        throw new InvalidOperationException("Type NLog.LogEventInfo was not found.");
+                    }
+                    MethodInfo createLogEventInfoMethodInfo = logEventInfoType.GetMethodPortable("Create",
+                        logEventLevelType, typeof(string), typeof(Exception), typeof(IFormatProvider), typeof(string), typeof(object[]));
+                    ParameterExpression loggerNameParam = Expression.Parameter(typeof(string));
+                    ParameterExpression levelParam = Expression.Parameter(typeof(object));
+                    ParameterExpression messageParam = Expression.Parameter(typeof(string));
+                    ParameterExpression exceptionParam = Expression.Parameter(typeof(Exception));
+                    UnaryExpression levelCast = Expression.Convert(levelParam, logEventLevelType);
+                    MethodCallExpression createLogEventInfoMethodCall = Expression.Call(null,
+                        createLogEventInfoMethodInfo,
+                        levelCast, loggerNameParam, exceptionParam,
+                        Expression.Constant(null, typeof(IFormatProvider)), messageParam, Expression.Constant(null, typeof(object[])));
+                    _logEventInfoFact = Expression.Lambda<Func<string, object, string, Exception, object>>(createLogEventInfoMethodCall,
+                        loggerNameParam, levelParam, messageParam, exceptionParam).Compile();
+                }
+                catch { }
+            }
+
             internal NLogLogger(dynamic logger)
             {
                 _logger = logger;
@@ -884,6 +921,43 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
                     return IsLogLevelEnable(logLevel);
                 }
                 messageFunc = LogMessageFormatter.SimulateStructuredLogging(messageFunc, formatParameters);
+
+                if (_logEventInfoFact != null)
+                {
+                    if (IsLogLevelEnable(logLevel))
+                    {
+                        var nlogLevel = this.TranslateLevel(logLevel);
+                        Type s_callerStackBoundaryType;
+#if !LIBLOG_PORTABLE
+                        StackTrace stack = new StackTrace();
+                        Type thisType = GetType();
+                        Type knownType0 = typeof(LoggerExecutionWrapper);
+                        Type knownType1 = typeof(LogExtensions);
+                        //Maybe inline, so we may can't found any LibLog classes in stack
+                        s_callerStackBoundaryType = null;
+                        for (var i = 0; i < stack.FrameCount; i++)
+                        {
+                            var declaringType = stack.GetFrame(i).GetMethod().DeclaringType;
+                            if (!IsInTypeHierarchy(thisType, declaringType) &&
+                                !IsInTypeHierarchy(knownType0, declaringType) &&
+                                !IsInTypeHierarchy(knownType1, declaringType))
+                            {
+                                if (i > 1)
+                                    s_callerStackBoundaryType = stack.GetFrame(i - 1).GetMethod().DeclaringType;
+                                break;
+                            }
+                        }
+#else
+                        s_callerStackBoundaryType = null;
+#endif
+                        if (s_callerStackBoundaryType != null)
+                            _logger.Log(s_callerStackBoundaryType, _logEventInfoFact(_logger.Name, nlogLevel, messageFunc(), exception));
+                        else
+                            _logger.Log(_logEventInfoFact(_logger.Name, nlogLevel, messageFunc(), exception));
+                        return true;
+                    }
+                    return false;
+                }
 
                 if(exception != null)
                 {
@@ -933,6 +1007,19 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
                             return true;
                         }
                         break;
+                }
+                return false;
+            }
+
+            private static bool IsInTypeHierarchy(Type currentType, Type checkType)
+            {
+                while (currentType != null && currentType != typeof(object))
+                {
+                    if (currentType == checkType)
+                    {
+                        return true;
+                    }
+                    currentType = currentType.GetBaseTypePortable();
                 }
                 return false;
             }
@@ -1004,6 +1091,27 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
                         return _logger.IsFatalEnabled;
                     default:
                         return _logger.IsTraceEnabled;
+                }
+            }
+
+            private object TranslateLevel(LogLevel logLevel)
+            {
+                switch (logLevel)
+                {
+                    case LogLevel.Trace:
+                        return _levelTrace;
+                    case LogLevel.Debug:
+                        return _levelDebug;
+                    case LogLevel.Info:
+                        return _levelInfo;
+                    case LogLevel.Warn:
+                        return _levelWarn;
+                    case LogLevel.Error:
+                        return _levelError;
+                    case LogLevel.Fatal:
+                        return _levelFatal;
+                    default:
+                        throw new ArgumentOutOfRangeException("logLevel", logLevel, null);
                 }
             }
         }
@@ -1129,7 +1237,9 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
             private readonly object _levelError;
             private readonly object _levelFatal;
             private readonly Func<object, object, bool> _isEnabledForDelegate;
-            private readonly Action<object, Type, object, string, Exception> _logDelegate;
+            private readonly Action<object, object> _logDelegate;
+            private readonly Func<object, Type, object, string, Exception, object> _createLoggingEvent;
+            private Action<object, string, object> _loggingEventPropertySetter;
 
             [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ILogger")]
             internal Log4NetLogger(dynamic logger)
@@ -1155,38 +1265,123 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
                 {
                     throw new InvalidOperationException("Type log4net.Core.ILogger, was not found.");
                 }
-                MethodInfo isEnabledMethodInfo = loggerType.GetMethodPortable("IsEnabledFor", logEventLevelType);
                 ParameterExpression instanceParam = Expression.Parameter(typeof(object));
                 UnaryExpression instanceCast = Expression.Convert(instanceParam, loggerType);
-                ParameterExpression callerStackBoundaryDeclaringTypeParam = Expression.Parameter(typeof(Type));
                 ParameterExpression levelParam = Expression.Parameter(typeof(object));
-                ParameterExpression messageParam = Expression.Parameter(typeof(string));
                 UnaryExpression levelCast = Expression.Convert(levelParam, logEventLevelType);
-                MethodCallExpression isEnabledMethodCall = Expression.Call(instanceCast, isEnabledMethodInfo, levelCast);
-                _isEnabledForDelegate = Expression.Lambda<Func<object, object, bool>>(isEnabledMethodCall, instanceParam, levelParam).Compile();
+                _isEnabledForDelegate = GetIsEnabledFor(loggerType, logEventLevelType, instanceCast, levelCast, instanceParam, levelParam);
 
-                // Action<object, object, string, Exception> Log =
-                // (logger, callerStackBoundaryDeclaringType, level, message, exception) => { ((ILogger)logger).Write(callerStackBoundaryDeclaringType, level, message, exception); }
+                Type loggingEventType = Type.GetType("log4net.Core.LoggingEvent, log4net");
+
+                _createLoggingEvent = GetCreateLoggingEvent(instanceParam, instanceCast, levelParam, levelCast, loggingEventType);
+
+                _logDelegate = GetLogDelegate(loggerType, loggingEventType, instanceCast, instanceParam);
+
+                _loggingEventPropertySetter = GetLoggingEventPropertySetter(loggingEventType);
+            }
+
+            private static Action<object, object> GetLogDelegate(Type loggerType, Type loggingEventType, UnaryExpression instanceCast,
+                                                 ParameterExpression instanceParam)
+            {
+                //Action<object, object, string, Exception> Log =
+                //(logger, callerStackBoundaryDeclaringType, level, message, exception) => { ((ILogger)logger).Log(new LoggingEvent(callerStackBoundaryDeclaringType, logger.Repository, logger.Name, level, message, exception)); }
                 MethodInfo writeExceptionMethodInfo = loggerType.GetMethodPortable("Log",
-                    typeof(Type),
-                    logEventLevelType,
-                    typeof(string),
-                    typeof(Exception));
-                ParameterExpression exceptionParam = Expression.Parameter(typeof(Exception));
+                                                                                   loggingEventType);
+
+                ParameterExpression loggingEventParameter =
+                    Expression.Parameter(typeof(object), "loggingEvent");
+
+                UnaryExpression loggingEventCasted =
+                    Expression.Convert(loggingEventParameter, loggingEventType);
+
                 var writeMethodExp = Expression.Call(
                     instanceCast,
                     writeExceptionMethodInfo,
-                    callerStackBoundaryDeclaringTypeParam,
-                    levelCast,
-                    messageParam,
-                    exceptionParam);
-                _logDelegate = Expression.Lambda<Action<object, Type, object, string, Exception>>(
-                    writeMethodExp,
-                    instanceParam,
-                    callerStackBoundaryDeclaringTypeParam,
-                    levelParam,
-                    messageParam,
-                    exceptionParam).Compile();
+                    loggingEventCasted);
+
+                var logDelegate = Expression.Lambda<Action<object, object>>(
+                                                writeMethodExp,
+                                                instanceParam,
+                                                loggingEventParameter).Compile();
+
+                return logDelegate;
+            }
+
+            private static Func<object, Type, object, string, Exception, object> GetCreateLoggingEvent(ParameterExpression instanceParam, UnaryExpression instanceCast, ParameterExpression levelParam, UnaryExpression levelCast, Type loggingEventType)
+            {
+                ParameterExpression callerStackBoundaryDeclaringTypeParam = Expression.Parameter(typeof(Type));
+                ParameterExpression messageParam = Expression.Parameter(typeof(string));
+                ParameterExpression exceptionParam = Expression.Parameter(typeof(Exception));
+
+                PropertyInfo repositoryProperty = loggingEventType.GetPropertyPortable("Repository");
+                PropertyInfo levelProperty = loggingEventType.GetPropertyPortable("Level");
+
+                ConstructorInfo loggingEventConstructor =
+                    loggingEventType.GetConstructorPortable(typeof(Type), repositoryProperty.PropertyType, typeof(string), levelProperty.PropertyType, typeof(object), typeof(Exception));
+
+                //Func<object, object, string, Exception, object> Log =
+                //(logger, callerStackBoundaryDeclaringType, level, message, exception) => new LoggingEvent(callerStackBoundaryDeclaringType, ((ILogger)logger).Repository, ((ILogger)logger).Name, (Level)level, message, exception); }
+                NewExpression newLoggingEventExpression =
+                    Expression.New(loggingEventConstructor,
+                                   callerStackBoundaryDeclaringTypeParam,
+                                   Expression.Property(instanceCast, "Repository"),
+                                   Expression.Property(instanceCast, "Name"),
+                                   levelCast,
+                                   messageParam,
+                                   exceptionParam);
+
+                var createLoggingEvent =
+                    Expression.Lambda<Func<object, Type, object, string, Exception, object>>(
+                                  newLoggingEventExpression,
+                                  instanceParam,
+                                  callerStackBoundaryDeclaringTypeParam,
+                                  levelParam,
+                                  messageParam,
+                                  exceptionParam)
+                              .Compile();
+
+                return createLoggingEvent;
+            }
+
+            private static Func<object, object, bool> GetIsEnabledFor(Type loggerType, Type logEventLevelType,
+                                                                      UnaryExpression instanceCast,
+                                                                      UnaryExpression levelCast,
+                                                                      ParameterExpression instanceParam,
+                                                                      ParameterExpression levelParam)
+            {
+                MethodInfo isEnabledMethodInfo = loggerType.GetMethodPortable("IsEnabledFor", logEventLevelType);
+                MethodCallExpression isEnabledMethodCall = Expression.Call(instanceCast, isEnabledMethodInfo, levelCast);
+
+                Func<object, object, bool> result =
+                    Expression.Lambda<Func<object, object, bool>>(isEnabledMethodCall, instanceParam, levelParam)
+                              .Compile();
+
+                return result;
+            }
+
+            private static Action<object, string, object> GetLoggingEventPropertySetter(Type loggingEventType)
+            {
+                ParameterExpression loggingEventParameter = Expression.Parameter(typeof(object), "loggingEvent");
+                ParameterExpression keyParameter = Expression.Parameter(typeof(string), "key");
+                ParameterExpression valueParameter = Expression.Parameter(typeof(object), "value");
+
+                PropertyInfo propertiesProperty = loggingEventType.GetPropertyPortable("Properties");
+                PropertyInfo item = propertiesProperty.PropertyType.GetPropertyPortable("Item");
+
+                // ((LoggingEvent)loggingEvent).Properties[key] = value;
+                var body =
+                    Expression.Assign(
+                        Expression.Property(
+                            Expression.Property(Expression.Convert(loggingEventParameter, loggingEventType),
+                                                propertiesProperty), item, keyParameter), valueParameter);
+
+                Action<object, string, object> result =
+                    Expression.Lambda<Action<object, string, object>>
+                              (body, loggingEventParameter, keyParameter,
+                               valueParameter)
+                              .Compile();
+
+                return result;
             }
 
             public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
@@ -1201,7 +1396,14 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
                     return false;
                 }
 
-                messageFunc = LogMessageFormatter.SimulateStructuredLogging(messageFunc, formatParameters);
+                string message = messageFunc();
+
+                IEnumerable<string> patternMatches;
+
+                string formattedMessage =
+                    LogMessageFormatter.FormatStructuredMessage(message,
+                                                                formatParameters,
+                                                                out patternMatches);
 
                 // determine correct caller - this might change due to jit optimizations with method inlining
                 if (s_callerStackBoundaryType == null)
@@ -1227,8 +1429,26 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
                 }
 
                 var translatedLevel = TranslateLevel(logLevel);
-                _logDelegate(_logger, s_callerStackBoundaryType, translatedLevel, messageFunc(), exception);
+
+                object loggingEvent = _createLoggingEvent(_logger, s_callerStackBoundaryType, translatedLevel, formattedMessage, exception);
+
+                PopulateProperties(loggingEvent, patternMatches, formatParameters);
+
+                _logDelegate(_logger, loggingEvent);
+
                 return true;
+            }
+
+            private void PopulateProperties(object loggingEvent, IEnumerable<string> patternMatches, object[] formatParameters)
+            {
+                IEnumerable<KeyValuePair<string, object>> keyToValue =
+                    patternMatches.Zip(formatParameters,
+                                       (key, value) => new KeyValuePair<string, object>(key, value));
+
+                foreach (KeyValuePair<string, object> keyValuePair in keyToValue)
+                {
+                    _loggingEventPropertySetter(loggingEvent, keyValuePair.Key, keyValuePair.Value);
+                }
             }
 
             private static bool IsInTypeHierarchy(Type currentType, Type checkType)
@@ -1373,7 +1593,7 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
             Expression severityParameter, ParameterExpression logNameParameter)
         {
             var entryType = LogEntryType;
-            MemberInitExpression memberInit = Expression.MemberInit(Expression.New(entryType), 
+            MemberInitExpression memberInit = Expression.MemberInit(Expression.New(entryType),
                 Expression.Bind(entryType.GetPropertyPortable("Message"), message),
                 Expression.Bind(entryType.GetPropertyPortable("Severity"), severityParameter),
                 Expression.Bind(
@@ -1489,12 +1709,15 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
 
         private static Func<string, string, IDisposable> GetPushProperty()
         {
-            Type ndcContextType = Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx");
+            Type ndcContextType = Type.GetType("Serilog.Context.LogContext, Serilog") ?? 
+                                  Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx");
+
             MethodInfo pushPropertyMethod = ndcContextType.GetMethodPortable(
                 "PushProperty", 
                 typeof(string),
                 typeof(object),
                 typeof(bool));
+
             ParameterExpression nameParam = Expression.Parameter(typeof(string), "name");
             ParameterExpression valueParam = Expression.Parameter(typeof(object), "value");
             ParameterExpression destructureObjectParam = Expression.Parameter(typeof(bool), "destructureObjects");
@@ -1849,7 +2072,12 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
 
     internal static class LogMessageFormatter
     {
-        private static readonly Regex Pattern = new Regex(@"\{@?\w{1,}\}");
+        //private static readonly Regex Pattern = new Regex(@"\{@?\w{1,}\}");
+#if LIBLOG_PORTABLE
+        private static readonly Regex Pattern = new Regex(@"(?<!{){@?(?<arg>[^\d{][^ }]*)}");
+#else
+        private static readonly Regex Pattern = new Regex(@"(?<!{){@?(?<arg>[^ :{}]+)(?<format>:[^}]+)?}", RegexOptions.Compiled);
+#endif
 
         /// <summary>
         /// Some logging frameworks support structured logging, such as serilog. This will allow you to add names to structured data in a format string:
@@ -1871,24 +2099,8 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
             return () =>
             {
                 string targetMessage = messageBuilder();
-                int argumentIndex = 0;
-                foreach (Match match in Pattern.Matches(targetMessage))
-                {
-                    int notUsed;
-                    if (!int.TryParse(match.Value.Substring(1, match.Value.Length -2), out notUsed))
-                    {
-                        targetMessage = ReplaceFirst(targetMessage, match.Value,
-                            "{" + argumentIndex++ + "}");
-                    }
-                }
-                try
-                {
-                    return string.Format(CultureInfo.InvariantCulture, targetMessage, formatParameters);
-                }
-                catch (FormatException ex)
-                {
-                    throw new FormatException("The input string '" + targetMessage + "' could not be formatted using string.Format", ex);
-                }
+                IEnumerable<string> patternMatches;
+                return FormatStructuredMessage(targetMessage, formatParameters, out patternMatches);
             };
         }
 
@@ -1901,10 +2113,62 @@ namespace ConfigR.Tests.Smoke.Service.Logging.LogProviders
             }
             return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
         }
+
+        public static string FormatStructuredMessage(string targetMessage, object[] formatParameters, out IEnumerable<string> patternMatches)
+        {
+            if (formatParameters.Length == 0)
+            {
+                patternMatches = Enumerable.Empty<string>();
+                return targetMessage;
+            }
+
+            List<string> processedArguments = new List<string>();
+            patternMatches = processedArguments;
+
+            foreach (Match match in Pattern.Matches(targetMessage))
+            {
+                var arg = match.Groups["arg"].Value;
+
+                int notUsed;
+                if (!int.TryParse(arg, out notUsed))
+                {
+                    int argumentIndex = processedArguments.IndexOf(arg);
+                    if (argumentIndex == -1)
+                    {
+                        argumentIndex = processedArguments.Count;
+                        processedArguments.Add(arg);
+                    }
+
+                    targetMessage = ReplaceFirst(targetMessage, match.Value,
+                        "{" + argumentIndex + match.Groups["format"].Value + "}");
+                }
+            }
+            try
+            {
+                return string.Format(CultureInfo.InvariantCulture, targetMessage, formatParameters);
+            }
+            catch (FormatException ex)
+            {
+                throw new FormatException("The input string '" + targetMessage + "' could not be formatted using string.Format", ex);
+            }
+        }
     }
 
     internal static class TypeExtensions
     {
+        internal static ConstructorInfo GetConstructorPortable(this Type type, params Type[] types)
+        {
+#if LIBLOG_PORTABLE
+            return type.GetTypeInfo().DeclaredConstructors.FirstOrDefault
+                       (constructor =>
+                            constructor.GetParameters()
+                                       .Select(parameter => parameter.ParameterType)
+                                       .SequenceEqual(types));
+#else
+            return type.GetConstructor(types);
+#endif
+        }
+
         internal static MethodInfo GetMethodPortable(this Type type, string name)
         {
 #if LIBLOG_PORTABLE

--- a/tests/ConfigR.Tests.Smoke.Service/ConfigR.Tests.Smoke.Service.csproj
+++ b/tests/ConfigR.Tests.Smoke.Service/ConfigR.Tests.Smoke.Service.csproj
@@ -49,11 +49,11 @@
     <Compile Include="Settings.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
@@ -64,9 +64,8 @@
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.4.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -88,8 +87,8 @@
       <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.5.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
@@ -104,13 +103,13 @@
       <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.4.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/tests/ConfigR.Tests.Smoke.Service/ConfigR.Tests.Smoke.Service.csproj
+++ b/tests/ConfigR.Tests.Smoke.Service/ConfigR.Tests.Smoke.Service.csproj
@@ -49,11 +49,11 @@
     <Compile Include="Settings.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
@@ -109,8 +109,8 @@
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/tests/ConfigR.Tests.Smoke.Service/app.config
+++ b/tests/ConfigR.Tests.Smoke.Service/app.config
@@ -15,11 +15,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.2.0" newVersion="1.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -27,7 +27,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.2.0" newVersion="1.4.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -35,7 +35,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Scripting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -55,7 +55,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/ConfigR.Tests.Smoke.Service/app.config
+++ b/tests/ConfigR.Tests.Smoke.Service/app.config
@@ -15,7 +15,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -35,7 +35,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Scripting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -52,6 +52,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/ConfigR.Tests.Smoke.Service/packages.config
+++ b/tests/ConfigR.Tests.Smoke.Service/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LibLog" version="4.2.5" targetFramework="net46" developmentDependency="true" />
+  <package id="LibLog" version="4.2.6" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.1.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.2.0" targetFramework="net46" />
   <package id="NLog" version="4.3.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
@@ -28,7 +28,7 @@
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Runtime.Handles" version="4.0.0" targetFramework="net46" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
@@ -42,7 +42,7 @@
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />

--- a/tests/ConfigR.Tests.Smoke.Service/packages.config
+++ b/tests/ConfigR.Tests.Smoke.Service/packages.config
@@ -2,13 +2,13 @@
 <packages>
   <package id="LibLog" version="4.2.6" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.3.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.3.1" targetFramework="net46" />
   <package id="NLog" version="4.3.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net46" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
@@ -24,7 +24,7 @@
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.5.0" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
@@ -36,13 +36,13 @@
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
-  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding.CodePages" version="4.4.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />

--- a/tests/ConfigR.Tests.Smoke.VSHostingProcess/App.config
+++ b/tests/ConfigR.Tests.Smoke.VSHostingProcess/App.config
@@ -15,11 +15,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.2.0" newVersion="1.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -27,7 +27,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.2.0" newVersion="1.4.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -35,7 +35,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Scripting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -55,7 +55,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/ConfigR.Tests.Smoke.VSHostingProcess/App.config
+++ b/tests/ConfigR.Tests.Smoke.VSHostingProcess/App.config
@@ -15,7 +15,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -35,7 +35,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Scripting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -52,6 +52,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/ConfigR.Tests.Smoke.VSHostingProcess/ConfigR.Tests.Smoke.VSHostingProcess.csproj
+++ b/tests/ConfigR.Tests.Smoke.VSHostingProcess/ConfigR.Tests.Smoke.VSHostingProcess.csproj
@@ -67,11 +67,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
@@ -82,9 +82,8 @@
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.4.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -106,8 +105,8 @@
       <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.5.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
@@ -122,13 +121,13 @@
       <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.4.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/tests/ConfigR.Tests.Smoke.VSHostingProcess/ConfigR.Tests.Smoke.VSHostingProcess.csproj
+++ b/tests/ConfigR.Tests.Smoke.VSHostingProcess/ConfigR.Tests.Smoke.VSHostingProcess.csproj
@@ -67,11 +67,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
@@ -127,8 +127,8 @@
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/tests/ConfigR.Tests.Smoke.VSHostingProcess/packages.config
+++ b/tests/ConfigR.Tests.Smoke.VSHostingProcess/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.1.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.2.0" targetFramework="net46" />
   <package id="NLog" version="4.3.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
@@ -27,7 +27,7 @@
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Runtime.Handles" version="4.0.0" targetFramework="net46" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
@@ -41,7 +41,7 @@
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />

--- a/tests/ConfigR.Tests.Smoke.VSHostingProcess/packages.config
+++ b/tests/ConfigR.Tests.Smoke.VSHostingProcess/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.3.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.3.1" targetFramework="net46" />
   <package id="NLog" version="4.3.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net46" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
@@ -23,7 +23,7 @@
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.5.0" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
@@ -35,13 +35,13 @@
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
-  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding.CodePages" version="4.4.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />

--- a/tests/ConfigR.Tests.Smoke.Website/ConfigR.Tests.Smoke.Website.csproj
+++ b/tests/ConfigR.Tests.Smoke.Website/ConfigR.Tests.Smoke.Website.csproj
@@ -81,11 +81,11 @@
     <Content Include="Web.csx" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Nancy, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
@@ -145,8 +145,8 @@
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />

--- a/tests/ConfigR.Tests.Smoke.Website/ConfigR.Tests.Smoke.Website.csproj
+++ b/tests/ConfigR.Tests.Smoke.Website/ConfigR.Tests.Smoke.Website.csproj
@@ -23,6 +23,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -81,11 +82,11 @@
     <Content Include="Web.csx" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.2.0\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Nancy, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
@@ -100,9 +101,8 @@
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.4.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -124,8 +124,8 @@
       <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.5.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
@@ -140,13 +140,13 @@
       <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.4.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />

--- a/tests/ConfigR.Tests.Smoke.Website/Web.config
+++ b/tests/ConfigR.Tests.Smoke.Website/Web.config
@@ -30,7 +30,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -50,7 +50,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Scripting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
@@ -71,6 +71,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/ConfigR.Tests.Smoke.Website/Web.config
+++ b/tests/ConfigR.Tests.Smoke.Website/Web.config
@@ -30,11 +30,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.2.0" newVersion="1.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -42,7 +42,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.2.0" newVersion="1.4.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -50,7 +50,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Scripting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
@@ -74,7 +74,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/ConfigR.Tests.Smoke.Website/packages.config
+++ b/tests/ConfigR.Tests.Smoke.Website/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.1.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.2.0" targetFramework="net46" />
   <package id="Nancy" version="1.4.3" targetFramework="net46" />
   <package id="Nancy.Hosting.Aspnet" version="1.4.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
@@ -28,7 +28,7 @@
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Runtime.Handles" version="4.0.0" targetFramework="net46" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
@@ -42,7 +42,7 @@
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />

--- a/tests/ConfigR.Tests.Smoke.Website/packages.config
+++ b/tests/ConfigR.Tests.Smoke.Website/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.3.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.3.1" targetFramework="net46" />
   <package id="Nancy" version="1.4.3" targetFramework="net46" />
   <package id="Nancy.Hosting.Aspnet" version="1.4.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net46" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
@@ -24,7 +24,7 @@
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.5.0" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
@@ -36,13 +36,13 @@
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
-  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding.CodePages" version="4.4.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
-  <package id="System.ValueTuple" version="4.3.1" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />


### PR DESCRIPTION
 - updated to Roslyn 2.3.1
 - updated dependencies
 - updated test dependencies (ensures test run and are discoverable in VS 2017 15.3)
 - moved build to MSBuild 15
 - updated Nuget.exe used in the build process to 4.3.0
 - enabled C# 7.1