### PR TITLE
switch to Bullseye and SimpleExec

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Net.Compilers" version="2.4.0" />
-  <package id="simple-targets-csx" version="6.0.0" />
+  <package id="Bullseye" version="1.0.0-rc.4" />
   <package id="vswhere" version="2.2.11" />
   <package id="xunit.runner.console" version="2.1.0" />
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Microsoft.Net.Compilers" version="2.4.0" />
   <package id="Bullseye" version="1.0.0-rc.4" />
+  <package id="SimpleExec" version="2.2.0" />
   <package id="vswhere" version="2.2.11" />
   <package id="xunit.runner.console" version="2.1.0" />
 </packages>


### PR DESCRIPTION
- [Bullseye](https://github.com/adamralph/bullseye) replaces simple-targets-csx (it's a regular binary package instead of scripts, so can optionally be used in a [regular .NET project](https://github.com/xbehave/xbehave.net/blob/6d798877b4b891ce95ea8f2c5f9bee3d56a26bae/targets/Program.cs#L8)).
- [SimpleExec](https://github.com/adamralph/simple-exec/) wraps up command invocation, so removes the need to include local helpers